### PR TITLE
[FEAT] 사용자 정보 불러와서 db에 저장 

### DIFF
--- a/loan-mate/src/main/java/com/fisa/bank/common/config/security/CustomOAuth2SuccessHandler.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/config/security/CustomOAuth2SuccessHandler.java
@@ -28,15 +28,9 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
       HttpServletRequest request, HttpServletResponse response, Authentication authentication)
       throws IOException {
 
-    // 코어뱅킹 /me API 호출
     UserInfoResponse me = coreBankingClient.fetchOne("users/me", UserInfoResponse.class);
+    syncCoreBankUserUseCase.sync(me);
 
-    // 로그인/회원가입 처리
-    var result = syncCoreBankUserUseCase.sync(me);
-    log.info("Login result: {}", result);
-
-    // 끝! (리디렉션, 쿠키 설정 등 없음)
     response.getWriter().write("OK");
-    response.getWriter().flush();
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/dto/UserApplicationMapper.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/dto/UserApplicationMapper.java
@@ -1,0 +1,19 @@
+package com.fisa.bank.user.application.dto;
+
+import org.springframework.stereotype.Component;
+
+import com.fisa.bank.user.application.model.User;
+
+@Component
+public class UserApplicationMapper {
+
+  public User toDomain(UserInfoResponse info) {
+    return new User(
+        null, // 서비스 UserId는 아직 없음
+        info.name(),
+        info.address(),
+        info.job(),
+        info.creditLevel(),
+        info.customerLevel());
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/dto/UserInfoResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/dto/UserInfoResponse.java
@@ -1,0 +1,24 @@
+package com.fisa.bank.user.application.dto;
+
+import com.fisa.bank.user.application.model.CreditRating;
+import com.fisa.bank.user.application.model.CustomerLevel;
+
+/**
+ * 인증 서버의 /me 엔드포인트 응답 DTO
+ *
+ * @param userId 코어뱅킹 유저 ID (인증 서버에서 받은 ID)
+ * @param name 사용자 이름
+ * @param address 주소
+ * @param job 직업
+ * @param creditLevel 신용 등급
+ * @param customerLevel 고객 등급
+ */
+public record UserInfoResponse(
+    Long userId,
+    String name,
+    String address,
+    // LocalDate birthday,
+    // BigDecimal income,
+    String job,
+    CreditRating creditLevel,
+    CustomerLevel customerLevel) {}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/model/CreditRating.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/model/CreditRating.java
@@ -1,0 +1,10 @@
+package com.fisa.bank.user.application.model;
+
+public enum CreditRating {
+  AAA,
+  AA,
+  A,
+  B,
+  C,
+  D;
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/model/CustomerLevel.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/model/CustomerLevel.java
@@ -1,0 +1,9 @@
+package com.fisa.bank.user.application.model;
+
+public enum CustomerLevel {
+  VVIP,
+  VIP,
+  GOLD,
+  SILVER,
+  BRONZE;
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/model/User.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/model/User.java
@@ -1,0 +1,55 @@
+package com.fisa.bank.user.application.model;
+
+import lombok.Getter;
+
+@Getter
+public class User {
+
+  private final Long userId;
+  private String name;
+  private String address;
+  private String job;
+  private CreditRating creditLevel;
+  private CustomerLevel customerLevel;
+
+  public User(
+      Long userId,
+      String name,
+      String address,
+      String job,
+      CreditRating creditLevel,
+      CustomerLevel customerLevel) {
+    this.userId = userId;
+    this.name = name;
+    this.address = address;
+    this.job = job;
+    this.creditLevel = creditLevel;
+    this.customerLevel = customerLevel;
+  }
+
+  /** 이름 / 주소 / 직업 업데이트 */
+  public void updateProfile(String name, String address, String job) {
+    this.name = name;
+    this.address = address;
+    this.job = job;
+  }
+
+  /** 생일 / 소득 업데이트 */
+  /*
+  public void updatePersonalData(LocalDate birthday, BigDecimal income) {
+    this.birthday = birthday;
+    this.income = income;
+  } */
+
+  /** 신용등급 변경 */
+  public void updateCreditRating(CreditRating newRating) {
+    this.creditLevel = newRating;
+  }
+
+  /** 고객등급 업그레이드 */
+  public void upgradeCustomerLevel(CustomerLevel newLevel) {
+    if (newLevel.ordinal() < this.customerLevel.ordinal()) {
+      this.customerLevel = newLevel;
+    }
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/model/UserAuth.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/model/UserAuth.java
@@ -1,0 +1,23 @@
+package com.fisa.bank.user.application.model;
+
+import lombok.Getter;
+
+@Getter
+public class UserAuth {
+
+  private final Long id;
+
+  // 코어 뱅킹과 매핑
+  private final Long coreBankingUserId; // 외부 시스템 ID
+  private final Long serviceUserId; // 우리 서비스 User ID
+
+  public UserAuth(Long id, Long coreBankingUserId, Long serviceUserId) {
+    this.id = id;
+    this.coreBankingUserId = coreBankingUserId;
+    this.serviceUserId = serviceUserId;
+  }
+
+  public static UserAuth create(Long coreBankingUserId, Long serviceUserId) {
+    return new UserAuth(null, coreBankingUserId, serviceUserId);
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/repository/UserAuthRepository.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/repository/UserAuthRepository.java
@@ -1,0 +1,14 @@
+package com.fisa.bank.user.application.repository;
+
+import java.util.Optional;
+
+import com.fisa.bank.user.application.model.UserAuth;
+
+public interface UserAuthRepository {
+
+  Optional<UserAuth> findByCoreBankingUserId(Long coreBankingUserId);
+
+  Optional<UserAuth> findByServiceUserId(Long serviceUserId);
+
+  UserAuth save(UserAuth userAuth);
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/repository/UserRepository.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.fisa.bank.user.application.repository;
+
+import java.util.Optional;
+
+import com.fisa.bank.user.application.model.User;
+
+public interface UserRepository {
+
+  Optional<User> findById(Long userId);
+
+  User save(User user);
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/service/LoginResult.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/service/LoginResult.java
@@ -1,0 +1,6 @@
+package com.fisa.bank.user.application.service;
+
+public enum LoginResult {
+  LOGIN,
+  REGISTER
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/service/LoginService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/service/LoginService.java
@@ -1,0 +1,9 @@
+package com.fisa.bank.user.application.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService {}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultSyncCoreBankUserUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultSyncCoreBankUserUseCase.java
@@ -1,0 +1,69 @@
+package com.fisa.bank.user.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fisa.bank.user.application.dto.UserApplicationMapper;
+import com.fisa.bank.user.application.dto.UserInfoResponse;
+import com.fisa.bank.user.application.model.User;
+import com.fisa.bank.user.application.model.UserAuth;
+import com.fisa.bank.user.application.repository.UserAuthRepository;
+import com.fisa.bank.user.application.repository.UserRepository;
+import com.fisa.bank.user.application.service.LoginResult;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DefaultSyncCoreBankUserUseCase implements SyncCoreBankUserUseCase {
+  private final UserRepository userRepository;
+  private final UserAuthRepository userAuthRepository;
+  private final UserApplicationMapper mapper;
+
+  @Override
+  public LoginResult sync(UserInfoResponse info) {
+
+    // coreBankingUserId로 매핑 존재 여부 확인
+    var authOpt = userAuthRepository.findByCoreBankingUserId(info.userId());
+
+    // 이미 매핑된 기존 사용자
+    if (authOpt.isPresent()) {
+
+      Long userId = authOpt.get().getServiceUserId();
+
+      User existingUser =
+          userRepository
+              .findById(userId)
+              .orElseThrow(() -> new IllegalStateException("UserAuth는 있는데 User가 없음"));
+
+      // 기존 도메인 객체 값 변경
+      existingUser.updateProfile(info.name(), info.address(), info.job());
+
+      existingUser.updateCreditRating(info.creditLevel());
+      existingUser.upgradeCustomerLevel(info.customerLevel());
+
+      userRepository.save(existingUser);
+
+      return LoginResult.LOGIN;
+    }
+
+    // 신규 사용자 등록
+
+    // DTO → Domain 변환
+    User newUser = mapper.toDomain(info);
+
+    // User 저장 → PK(Long) 생성
+    newUser = userRepository.save(newUser);
+
+    // 사용자 매핑 생성
+    userAuthRepository.save(
+        new UserAuth(
+            null, // authId 자동
+            newUser.getUserId(), // 서비스 user PK
+            info.userId() // 코어뱅킹 user PK
+            ));
+
+    return LoginResult.REGISTER;
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultSyncCoreBankUserUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultSyncCoreBankUserUseCase.java
@@ -60,8 +60,8 @@ public class DefaultSyncCoreBankUserUseCase implements SyncCoreBankUserUseCase {
     userAuthRepository.save(
         new UserAuth(
             null, // authId 자동
-            newUser.getUserId(), // 서비스 user PK
-            info.userId() // 코어뱅킹 user PK
+            info.userId(), // 코어뱅킹 user PK
+            newUser.getUserId() // 서비스 user PK
             ));
 
     return LoginResult.REGISTER;

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/SyncCoreBankUserUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/SyncCoreBankUserUseCase.java
@@ -1,0 +1,8 @@
+package com.fisa.bank.user.application.usecase;
+
+import com.fisa.bank.user.application.dto.UserInfoResponse;
+import com.fisa.bank.user.application.service.LoginResult;
+
+public interface SyncCoreBankUserUseCase {
+  LoginResult sync(UserInfoResponse info);
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/UserAuthMapper.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/UserAuthMapper.java
@@ -1,0 +1,28 @@
+package com.fisa.bank.user.persistence;
+
+import org.springframework.stereotype.Component;
+
+import com.fisa.bank.user.application.model.UserAuth;
+import com.fisa.bank.user.persistence.entity.UserAuthEntity;
+import com.fisa.bank.user.persistence.entity.id.UserAuthId;
+
+@Component
+public class UserAuthMapper {
+
+  /** Domain → Entity */
+  public UserAuthEntity toEntity(UserAuth domain) {
+    return UserAuthEntity.builder()
+        .id(domain.getId() != null ? UserAuthId.of(domain.getId()) : null)
+        .coreBankingUserId(domain.getCoreBankingUserId())
+        .serviceUserId(domain.getServiceUserId())
+        .build();
+  }
+
+  /** Entity → Domain */
+  public UserAuth toDomain(UserAuthEntity entity) {
+    return new UserAuth(
+        entity.getId() != null ? entity.getId().getValue() : null,
+        entity.getCoreBankingUserId(),
+        entity.getServiceUserId());
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/UserMapper.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/UserMapper.java
@@ -1,0 +1,40 @@
+package com.fisa.bank.user.persistence;
+
+import org.springframework.stereotype.Component;
+
+import com.fisa.bank.user.application.model.User;
+import com.fisa.bank.user.persistence.entity.UserEntity;
+import com.fisa.bank.user.persistence.entity.id.UserId;
+
+@Component
+public class UserMapper {
+
+  public User toDomain(UserEntity entity) {
+    if (entity == null) {
+      return null;
+    }
+
+    return new User(
+        entity.getUserId() != null ? entity.getUserId().getValue() : null, // UserId → Long
+        entity.getName(),
+        entity.getAddress(),
+        entity.getJob(),
+        entity.getCreditLevel(),
+        entity.getCustomerLevel());
+  }
+
+  public UserEntity toEntity(User domain) {
+    if (domain == null) {
+      return null;
+    }
+
+    return UserEntity.builder()
+        .userId(domain.getUserId() != null ? UserId.of(domain.getUserId()) : null) // Long → UserId
+        .name(domain.getName())
+        .address(domain.getAddress())
+        .job(domain.getJob())
+        .creditLevel(domain.getCreditLevel())
+        .customerLevel(domain.getCustomerLevel())
+        .build();
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/UserAuthEntity.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/UserAuthEntity.java
@@ -1,0 +1,35 @@
+package com.fisa.bank.user.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import org.hibernate.annotations.JavaType;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.fisa.bank.user.persistence.entity.id.UserAuthId;
+import com.fisa.bank.user.persistence.entity.id.UserAuthIdJavaType;
+
+/** UserAuth 영속성 엔티티 (JPA Entity) 코어뱅킹 시스템의 사용자 인증 정보를 저장 */
+@Entity
+@Table(name = "user_auth_service")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class UserAuthEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @JavaType(UserAuthIdJavaType.class)
+  @JdbcTypeCode(SqlTypes.BIGINT)
+  private UserAuthId id;
+
+  /** 외부 시스템(CB)의 ID */
+  @Column(nullable = false, unique = true)
+  private Long coreBankingUserId;
+
+  /** 내부 UserEntity PK */
+  @Column(nullable = false, unique = true)
+  private Long serviceUserId;
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/UserEntity.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/UserEntity.java
@@ -1,0 +1,55 @@
+package com.fisa.bank.user.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import org.hibernate.annotations.JavaType;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.fisa.bank.common.persistence.entity.BaseEntity;
+import com.fisa.bank.user.application.model.CreditRating;
+import com.fisa.bank.user.application.model.CustomerLevel;
+import com.fisa.bank.user.persistence.entity.id.UserId;
+import com.fisa.bank.user.persistence.entity.id.UserIdJavaType;
+
+/** User 영속성 엔티티 (JPA Entity) DB 테이블과 매핑되는 클래스 */
+@Entity
+@Table(name = "user_service")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder
+public class UserEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @JavaType(UserIdJavaType.class)
+  @JdbcTypeCode(SqlTypes.BIGINT)
+  private UserId userId;
+
+  @Column(nullable = false)
+  private String name;
+
+  @Column(nullable = false)
+  private String address;
+
+  /*
+  @Column(nullable = false)
+  private LocalDate birthday; */
+
+  @Column(nullable = false)
+  private String job;
+
+  /*
+  @Column(nullable = false)
+  private BigDecimal income; */
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private CreditRating creditLevel;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private CustomerLevel customerLevel;
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/id/UserAuthId.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/id/UserAuthId.java
@@ -1,0 +1,18 @@
+package com.fisa.bank.user.persistence.entity.id;
+
+import com.fisa.bank.common.persistence.id.BaseId;
+
+public class UserAuthId extends BaseId<Long> {
+
+  protected UserAuthId() {
+    super();
+  }
+
+  private UserAuthId(Long value) {
+    super(value);
+  }
+
+  public static UserAuthId of(Long value) {
+    return new UserAuthId(value);
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/id/UserAuthIdJavaType.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/id/UserAuthIdJavaType.java
@@ -1,5 +1,6 @@
 package com.fisa.bank.user.persistence.entity.id;
 
+import org.hibernate.type.descriptor.java.LongJavaType;
 import org.hibernate.type.descriptor.jdbc.BigIntJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
@@ -7,15 +8,11 @@ import com.fisa.bank.common.persistence.id.BaseIdJavaType;
 
 public class UserAuthIdJavaType extends BaseIdJavaType<Long, UserAuthId> {
 
-  public static final UserIdJavaType INSTANCE = new UserIdJavaType();
+  public static final UserAuthIdJavaType INSTANCE = new UserAuthIdJavaType();
 
   private static final JdbcType BIGINT_JDBC_TYPE = BigIntJdbcType.INSTANCE;
 
   public UserAuthIdJavaType() {
-    super(
-        UserAuthId.class,
-        UserAuthId::of,
-        org.hibernate.type.descriptor.java.LongJavaType.INSTANCE,
-        BIGINT_JDBC_TYPE);
+    super(UserAuthId.class, UserAuthId::of, LongJavaType.INSTANCE, BIGINT_JDBC_TYPE);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/id/UserAuthIdJavaType.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/id/UserAuthIdJavaType.java
@@ -1,0 +1,21 @@
+package com.fisa.bank.user.persistence.entity.id;
+
+import org.hibernate.type.descriptor.jdbc.BigIntJdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+
+import com.fisa.bank.common.persistence.id.BaseIdJavaType;
+
+public class UserAuthIdJavaType extends BaseIdJavaType<Long, UserAuthId> {
+
+  public static final UserIdJavaType INSTANCE = new UserIdJavaType();
+
+  private static final JdbcType BIGINT_JDBC_TYPE = BigIntJdbcType.INSTANCE;
+
+  public UserAuthIdJavaType() {
+    super(
+        UserAuthId.class,
+        UserAuthId::of,
+        org.hibernate.type.descriptor.java.LongJavaType.INSTANCE,
+        BIGINT_JDBC_TYPE);
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/id/UserId.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/id/UserId.java
@@ -1,0 +1,18 @@
+package com.fisa.bank.user.persistence.entity.id;
+
+import com.fisa.bank.common.persistence.id.BaseId;
+
+public class UserId extends BaseId<Long> {
+
+  protected UserId() {
+    super();
+  }
+
+  private UserId(Long value) {
+    super(value);
+  }
+
+  public static UserId of(Long value) {
+    return new UserId(value);
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/id/UserIdJavaType.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/id/UserIdJavaType.java
@@ -1,5 +1,6 @@
 package com.fisa.bank.user.persistence.entity.id;
 
+import org.hibernate.type.descriptor.java.LongJavaType;
 import org.hibernate.type.descriptor.jdbc.BigIntJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
@@ -12,10 +13,6 @@ public class UserIdJavaType extends BaseIdJavaType<Long, UserId> {
   private static final JdbcType BIGINT_JDBC_TYPE = BigIntJdbcType.INSTANCE;
 
   public UserIdJavaType() {
-    super(
-        UserId.class,
-        UserId::of,
-        org.hibernate.type.descriptor.java.LongJavaType.INSTANCE,
-        BIGINT_JDBC_TYPE);
+    super(UserId.class, UserId::of, LongJavaType.INSTANCE, BIGINT_JDBC_TYPE);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/id/UserIdJavaType.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/id/UserIdJavaType.java
@@ -1,0 +1,21 @@
+package com.fisa.bank.user.persistence.entity.id;
+
+import org.hibernate.type.descriptor.jdbc.BigIntJdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+
+import com.fisa.bank.common.persistence.id.BaseIdJavaType;
+
+public class UserIdJavaType extends BaseIdJavaType<Long, UserId> {
+
+  public static final UserIdJavaType INSTANCE = new UserIdJavaType();
+
+  private static final JdbcType BIGINT_JDBC_TYPE = BigIntJdbcType.INSTANCE;
+
+  public UserIdJavaType() {
+    super(
+        UserId.class,
+        UserId::of,
+        org.hibernate.type.descriptor.java.LongJavaType.INSTANCE,
+        BIGINT_JDBC_TYPE);
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/JpaUserAuthRepository.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/JpaUserAuthRepository.java
@@ -1,0 +1,14 @@
+package com.fisa.bank.user.persistence.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.fisa.bank.user.persistence.entity.UserAuthEntity;
+import com.fisa.bank.user.persistence.entity.id.UserAuthId;
+
+public interface JpaUserAuthRepository extends JpaRepository<UserAuthEntity, UserAuthId> {
+  Optional<UserAuthEntity> findByCoreBankingUserId(Long coreBankingUserId);
+
+  Optional<UserAuthEntity> findByServiceUserId(Long serviceUserId);
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/JpaUserRepository.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/JpaUserRepository.java
@@ -1,0 +1,8 @@
+package com.fisa.bank.user.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.fisa.bank.user.persistence.entity.UserEntity;
+import com.fisa.bank.user.persistence.entity.id.UserId;
+
+public interface JpaUserRepository extends JpaRepository<UserEntity, UserId> {}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/UserAuthRepositoryImpl.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/UserAuthRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.fisa.bank.user.persistence.repository;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.fisa.bank.user.application.model.UserAuth;
+import com.fisa.bank.user.application.repository.UserAuthRepository;
+import com.fisa.bank.user.persistence.UserAuthMapper;
+import com.fisa.bank.user.persistence.entity.UserAuthEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class UserAuthRepositoryImpl implements UserAuthRepository {
+  private final JpaUserAuthRepository jpaRepo;
+  private final UserAuthMapper mapper;
+
+  @Override
+  public Optional<UserAuth> findByCoreBankingUserId(Long coreBankingUserId) {
+    return jpaRepo.findByCoreBankingUserId(coreBankingUserId).map(mapper::toDomain);
+  }
+
+  @Override
+  public Optional<UserAuth> findByServiceUserId(Long serviceUserId) {
+    return jpaRepo.findByServiceUserId(serviceUserId).map(mapper::toDomain);
+  }
+
+  @Override
+  public UserAuth save(UserAuth userAuth) {
+    UserAuthEntity saved = jpaRepo.save(mapper.toEntity(userAuth));
+    return mapper.toDomain(saved);
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/UserRepositoryImpl.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/UserRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.fisa.bank.user.persistence.repository;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.fisa.bank.user.application.model.User;
+import com.fisa.bank.user.application.repository.UserRepository;
+import com.fisa.bank.user.persistence.UserMapper;
+import com.fisa.bank.user.persistence.entity.UserEntity;
+import com.fisa.bank.user.persistence.entity.id.UserId;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+  private final JpaUserRepository jpaRepo;
+  private final UserMapper mapper;
+
+  @Override
+  public Optional<User> findById(Long id) {
+    return jpaRepo.findById(UserId.of(id)).map(mapper::toDomain);
+  }
+
+  @Override
+  public User save(User user) {
+    UserEntity saved = jpaRepo.save(mapper.toEntity(user));
+    return mapper.toDomain(saved);
+  }
+}


### PR DESCRIPTION
## 관련 이슈 
closes #22 

## 기능
- userInfo 가 아닌 /me 엔드포인트를 통해 사용자 정보를 불러옴
- 불러온 사용자 id(코어뱅킹 id) 와 서비스 id 를 매핑하는 UserAuth 엔티티 생성
- 부분적인 ddd 아키텍쳐를 사용해 application과 persistence 계층 분리 