### PR TITLE
[FEAT] 서비스 서버에 대출 해지 기능 추가

### DIFF
--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/CoreBankingClient.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/CoreBankingClient.java
@@ -6,4 +6,6 @@ public interface CoreBankingClient {
   <T> T fetchOne(String endpoint, Class<T> clazz);
 
   <T> List<T> fetchList(String endpoint, Class<T> clazz);
+
+  public void fetchOneDelete(String endpoint);
 }

--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/CoreBankingClientDevImpl.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/CoreBankingClientDevImpl.java
@@ -92,4 +92,14 @@ public class CoreBankingClientDevImpl implements CoreBankingClient {
         .map(n -> jsonNodeMapper.map(n, clazz))
         .collect(Collectors.toList());
   }
+
+  /**
+   * 단일 데이터 삭제
+   *
+   * @param endpoint 요청 URL
+   */
+  public void fetchOneDelete(String endpoint) {
+
+    callApi(endpoint);
+  }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/CoreBankingClientDevImpl.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/CoreBankingClientDevImpl.java
@@ -34,21 +34,22 @@ public class CoreBankingClientDevImpl implements CoreBankingClient {
     return builder.defaultHeader("Authorization", "Bearer " + token).build();
   }
 
-  private JsonNode executeRequest(String endpoint, String token, HttpMethod method) {
+  private <T> T executeRequest(
+      String endpoint, String token, HttpMethod method, Class<T> responseType) {
     return client(token)
         .method(method)
         .uri(baseUrl + endpoint)
         .retrieve()
-        .bodyToMono(JsonNode.class)
+        .bodyToMono(responseType)
         .block();
   }
 
   /** API 호출 + 토큰 만료 시 자동 재발급 */
-  private JsonNode callApi(String endpoint, HttpMethod method) {
+  private <T> T callApi(String endpoint, HttpMethod method, Class<T> responseType) {
     String token = tokenManager.getAccessToken();
 
     try {
-      return executeRequest(endpoint, token, method);
+      return executeRequest(endpoint, token, method, responseType);
 
     } catch (WebClientResponseException e) {
 
@@ -56,7 +57,7 @@ public class CoreBankingClientDevImpl implements CoreBankingClient {
         log.warn("AccessToken 재발급 후 재요청");
 
         String newToken = tokenManager.refreshAndGetNewToken();
-        return executeRequest(endpoint, newToken, method);
+        return executeRequest(endpoint, newToken, method, responseType);
       }
 
       log.error("CoreBanking 호출 실패: {} {}", e.getStatusCode(), e.getMessage());
@@ -70,7 +71,7 @@ public class CoreBankingClientDevImpl implements CoreBankingClient {
 
   @Override
   public <T> T fetchOne(String endpoint, Class<T> clazz) {
-    JsonNode root = callApi(endpoint, HttpMethod.GET);
+    JsonNode root = callApi(endpoint, HttpMethod.GET, JsonNode.class);
 
     if (root == null || root.isNull()) {
       throw new IllegalStateException("응답이 null 입니다.");
@@ -81,7 +82,7 @@ public class CoreBankingClientDevImpl implements CoreBankingClient {
 
   @Override
   public <T> List<T> fetchList(String endpoint, Class<T> clazz) {
-    JsonNode root = callApi(endpoint, HttpMethod.GET);
+    JsonNode root = callApi(endpoint, HttpMethod.GET, JsonNode.class);
 
     JsonNode arr = root.path("data");
 
@@ -101,6 +102,6 @@ public class CoreBankingClientDevImpl implements CoreBankingClient {
    */
   public void fetchOneDelete(String endpoint) {
 
-    callApi(endpoint, HttpMethod.DELETE);
+    callApi(endpoint, HttpMethod.DELETE, Void.class);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/CoreBankingClientProdImpl.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/CoreBankingClientProdImpl.java
@@ -118,4 +118,15 @@ public class CoreBankingClientProdImpl implements CoreBankingClient {
         .map(node -> jsonNodeMapper.map(node, clazz))
         .collect(Collectors.toList());
   }
+
+  /**
+   * 단일 데이터 삭제
+   *
+   * @param endpoint 요청 URL
+   */
+  public void fetchOneDelete(String endpoint) {
+    Authentication auth = getAuth();
+    String token = getAccessToken(auth);
+    getClient(token).delete().uri(BASE_URL + endpoint).retrieve().bodyToMono(Void.class).block();
+  }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -84,7 +84,6 @@ public class LoanService implements ManageLoanUseCase {
   }
 
   @Override
-  @Transactional
   public void cancelLoan(Long loanId) {
     String url = "/loans/" + loanId;
     coreBankingClient.fetchOneDelete(url);

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fisa.bank.loan.application.dto.response.LoanAutoDepositResponse;
+import com.fisa.bank.common.application.service.CoreBankingClient;
 import com.fisa.bank.loan.application.dto.response.LoanDetailResponse;
 import com.fisa.bank.loan.application.dto.response.LoanListResponse;
 import com.fisa.bank.loan.application.model.LoanDetail;
@@ -26,6 +27,7 @@ import com.fisa.bank.persistence.loan.entity.LoanLedger;
 public class LoanService implements ManageLoanUseCase {
 
   private final LoanReader loanReader;
+  private final CoreBankingClient coreBankingClient;
 
   @Override
   @Transactional
@@ -79,5 +81,12 @@ public class LoanService implements ManageLoanUseCase {
     LoanLedger loanLedger = loanReader.findLoanLedgerById(loanId);
 
     return LoanAutoDepositResponse.from(loanLedger);
+  }
+
+  @Override
+  @Transactional
+  public void cancelLoan(Long loanId) {
+    String url = "/loans/" + loanId;
+    coreBankingClient.fetchOneDelete(url);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -13,8 +13,8 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fisa.bank.loan.application.dto.response.LoanAutoDepositResponse;
 import com.fisa.bank.common.application.service.CoreBankingClient;
+import com.fisa.bank.loan.application.dto.response.LoanAutoDepositResponse;
 import com.fisa.bank.loan.application.dto.response.LoanDetailResponse;
 import com.fisa.bank.loan.application.dto.response.LoanListResponse;
 import com.fisa.bank.loan.application.model.LoanDetail;

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/usecase/ManageLoanUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/usecase/ManageLoanUseCase.java
@@ -13,4 +13,6 @@ public interface ManageLoanUseCase {
   LoanDetailResponse getLoanDetail(Long loanId);
 
   LoanAutoDepositResponse getAutoDeposit(Long loanId);
+
+  void cancelLoan(Long loanId);
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import com.fisa.bank.common.presentation.response.ApiResponse;
@@ -47,10 +48,9 @@ public class LoanController {
   }
 
   @DeleteMapping("{loanId:\\d+}")
-  public ApiResponse<SuccessBody<Void>> deleteLoan(@PathVariable("loanId") Long loanId) {
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void deleteLoan(@PathVariable("loanId") Long loanId) {
     log.info("대출 해지");
     manageLoanUseCase.cancelLoan(loanId);
-
-    return ApiResponseGenerator.success(ResponseCode.DELETE);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
@@ -5,10 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.fisa.bank.common.presentation.response.ApiResponse;
 import com.fisa.bank.common.presentation.response.ApiResponseGenerator;
@@ -47,5 +44,13 @@ public class LoanController {
     LoanAutoDepositResponse response = manageLoanUseCase.getAutoDeposit(loanId);
 
     return ApiResponseGenerator.success(ResponseCode.GET, response);
+  }
+
+  @DeleteMapping("{loanId:\\d+}")
+  public ApiResponse<SuccessBody<Void>> deleteLoan(@PathVariable("loanId") Long loanId) {
+    log.info("대출 해지");
+    manageLoanUseCase.cancelLoan(loanId);
+
+    return ApiResponseGenerator.success(ResponseCode.DELETE);
   }
 }

--- a/loan-mate/src/main/resources/application.yml
+++ b/loan-mate/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
     import:
       - classpath:application-db.yml
       - classpath:application-auth.yml
+      - classpath:application-cdc.yml
       - classpath:env.properties
   profiles:
     active: ${PROFILE}


### PR DESCRIPTION
## 관련 이슈
#10 

## 추가한 기능
- 서비스 서버에 대출 해지 API 추가했습니다.
- 코어 뱅킹에 대출 해지 API 호출하는 방식입니다.
- CoreBankingClient 에 delete 요청 호출하는 기능 추가했습니다.