### PR TITLE
[FIX] core banking client http 메소드 동적으로 변경

### DIFF
--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/CoreBankingClientDevImpl.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/CoreBankingClientDevImpl.java
@@ -34,21 +34,22 @@ public class CoreBankingClientDevImpl implements CoreBankingClient {
     return builder.defaultHeader("Authorization", "Bearer " + token).build();
   }
 
-  private JsonNode executeRequest(String endpoint, String token, HttpMethod method) {
+  private <T> T executeRequest(
+      String endpoint, String token, HttpMethod method, Class<T> responseType) {
     return client(token)
         .method(method)
         .uri(baseUrl + endpoint)
         .retrieve()
-        .bodyToMono(JsonNode.class)
+        .bodyToMono(responseType)
         .block();
   }
 
   /** API 호출 + 토큰 만료 시 자동 재발급 */
-  private JsonNode callApi(String endpoint, HttpMethod method) {
+  private <T> T callApi(String endpoint, HttpMethod method, Class<T> responseType) {
     String token = tokenManager.getAccessToken();
 
     try {
-      return executeRequest(endpoint, token, method);
+      return executeRequest(endpoint, token, method, responseType);
 
     } catch (WebClientResponseException e) {
 
@@ -56,7 +57,7 @@ public class CoreBankingClientDevImpl implements CoreBankingClient {
         log.warn("AccessToken 재발급 후 재요청");
 
         String newToken = tokenManager.refreshAndGetNewToken();
-        return executeRequest(endpoint, newToken, method);
+        return executeRequest(endpoint, newToken, method, responseType);
       }
 
       log.error("CoreBanking 호출 실패: {} {}", e.getStatusCode(), e.getMessage());
@@ -70,7 +71,7 @@ public class CoreBankingClientDevImpl implements CoreBankingClient {
 
   @Override
   public <T> T fetchOne(String endpoint, Class<T> clazz) {
-    JsonNode root = callApi(endpoint, HttpMethod.GET);
+    JsonNode root = callApi(endpoint, HttpMethod.GET, JsonNode.class);
 
     if (root == null || root.isNull()) {
       throw new IllegalStateException("응답이 null 입니다.");
@@ -81,7 +82,7 @@ public class CoreBankingClientDevImpl implements CoreBankingClient {
 
   @Override
   public <T> List<T> fetchList(String endpoint, Class<T> clazz) {
-    JsonNode root = callApi(endpoint, HttpMethod.GET);
+    JsonNode root = callApi(endpoint, HttpMethod.GET, JsonNode.class);
 
     JsonNode arr = root.path("data");
 
@@ -101,6 +102,6 @@ public class CoreBankingClientDevImpl implements CoreBankingClient {
    */
   public void fetchOneDelete(String endpoint) {
 
-    callApi(endpoint, HttpMethod.DELETE);
+    callApi(endpoint, HttpMethod.DELETE, Void.class);
   }
 }


### PR DESCRIPTION
## 수정 사항
HttpMethod 타입을 지정해서 callApi, executeRequest 메소드 파라미터로 넘겨주는 방식으로 수정했습니다.