### PR TITLE
[REFACTOR] 서비스 로직에서 Entity 제거 및 Loan 도메인 중심으로 리팩토링

### DIFF
--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoanAutoDepositResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoanAutoDepositResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-import com.fisa.bank.persistence.loan.entity.LoanLedger;
+import com.fisa.bank.loan.application.model.Loan;
 
 @Getter
 @Builder
@@ -14,11 +14,11 @@ public class LoanAutoDepositResponse {
   private LocalDateTime nextRepaymentDate;
   private Boolean autoDepositEnabled;
 
-  public static LoanAutoDepositResponse from(LoanLedger loanLedger) {
+  public static LoanAutoDepositResponse from(Loan loan) {
     return LoanAutoDepositResponse.builder()
-        .loanLedgerId(loanLedger.getLoanLedgerId().getValue())
-        .nextRepaymentDate(loanLedger.getNextRepaymentDate())
-        .autoDepositEnabled(loanLedger.isAutoDepositEnabled())
+        .loanLedgerId(loan.getLoanId())
+        .nextRepaymentDate(loan.getNextRepaymentDate())
+        .autoDepositEnabled(loan.getAutoDepositEnabled())
         .build();
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/model/Loan.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/model/Loan.java
@@ -3,6 +3,8 @@ package com.fisa.bank.loan.application.model;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
+
 import com.fisa.bank.loan.persistence.enums.RiskLevel;
 
 @Getter
@@ -12,4 +14,6 @@ public class Loan {
   private final String loanName;
   private RiskLevel riskLevel;
   private LoanDetail loanDetail;
+  private final LocalDateTime nextRepaymentDate;
+  private final Boolean autoDepositEnabled;
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/repository/LoanRepository.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/repository/LoanRepository.java
@@ -1,6 +1,7 @@
 package com.fisa.bank.loan.application.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.fisa.bank.loan.application.model.Loan;
 import com.fisa.bank.persistence.user.entity.id.UserId;
@@ -8,4 +9,6 @@ import com.fisa.bank.persistence.user.entity.id.UserId;
 public interface LoanRepository {
 
   List<Loan> getLoans(UserId userId);
+
+  Optional<Loan> findById(Long loanId);
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -17,10 +17,10 @@ import com.fisa.bank.common.application.service.CoreBankingClient;
 import com.fisa.bank.loan.application.dto.response.LoanAutoDepositResponse;
 import com.fisa.bank.loan.application.dto.response.LoanDetailResponse;
 import com.fisa.bank.loan.application.dto.response.LoanListResponse;
+import com.fisa.bank.loan.application.model.Loan;
 import com.fisa.bank.loan.application.model.LoanDetail;
 import com.fisa.bank.loan.application.service.reader.LoanReader;
 import com.fisa.bank.loan.application.usecase.ManageLoanUseCase;
-import com.fisa.bank.persistence.loan.entity.LoanLedger;
 
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -78,9 +78,9 @@ public class LoanService implements ManageLoanUseCase {
   @Transactional(readOnly = true)
   public LoanAutoDepositResponse getAutoDeposit(Long loanId) {
 
-    LoanLedger loanLedger = loanReader.findLoanLedgerById(loanId);
+    Loan loan = loanReader.findLoanById(loanId);
 
-    return LoanAutoDepositResponse.from(loanLedger);
+    return LoanAutoDepositResponse.from(loan);
   }
 
   @Override

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
@@ -12,6 +12,7 @@ import com.fisa.bank.loan.application.exception.LoanLedgerNotFoundException;
 import com.fisa.bank.loan.application.model.Loan;
 import com.fisa.bank.loan.application.model.LoanDetail;
 import com.fisa.bank.loan.application.repository.LoanRepository;
+import com.fisa.bank.loan.persistence.repository.LoanRepositoryImpl;
 import com.fisa.bank.persistence.loan.entity.LoanLedger;
 import com.fisa.bank.persistence.loan.entity.id.LoanLedgerId;
 import com.fisa.bank.persistence.loan.repository.LoanLedgerRepository;
@@ -35,9 +36,12 @@ public class LoanReader {
     return loanRepository.getLoans(UserId.of(userId));
   }
 
-  public LoanLedger findLoanLedgerById(Long loanId) {
-    return loanLedgerRepository
-        .findById(LoanLedgerId.of(loanId))
-        .orElseThrow(() -> new LoanLedgerNotFoundException(loanId));
+  public Loan findLoanById(Long loanId) {
+    LoanLedger ledger =
+        loanLedgerRepository
+            .findById(LoanLedgerId.of(loanId))
+            .orElseThrow(() -> new LoanLedgerNotFoundException(loanId));
+
+    return LoanRepositoryImpl.toDomain(ledger);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
@@ -12,9 +12,6 @@ import com.fisa.bank.loan.application.exception.LoanLedgerNotFoundException;
 import com.fisa.bank.loan.application.model.Loan;
 import com.fisa.bank.loan.application.model.LoanDetail;
 import com.fisa.bank.loan.application.repository.LoanRepository;
-import com.fisa.bank.loan.persistence.repository.LoanRepositoryImpl;
-import com.fisa.bank.persistence.loan.entity.LoanLedger;
-import com.fisa.bank.persistence.loan.entity.id.LoanLedgerId;
 import com.fisa.bank.persistence.loan.repository.LoanLedgerRepository;
 import com.fisa.bank.persistence.user.entity.id.UserId;
 
@@ -37,11 +34,8 @@ public class LoanReader {
   }
 
   public Loan findLoanById(Long loanId) {
-    LoanLedger ledger =
-        loanLedgerRepository
-            .findById(LoanLedgerId.of(loanId))
-            .orElseThrow(() -> new LoanLedgerNotFoundException(loanId));
-
-    return LoanRepositoryImpl.toDomain(ledger);
+    return loanRepository
+        .findById(loanId)
+        .orElseThrow(() -> new LoanLedgerNotFoundException(loanId));
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/persistence/repository/LoanRepositoryImpl.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/persistence/repository/LoanRepositoryImpl.java
@@ -28,7 +28,11 @@ public class LoanRepositoryImpl implements LoanRepository {
   }
 
   public static Loan toDomain(LoanLedger loanLedger) {
-    return new Loan(loanLedger.getLoanLedgerId().getValue(), loanLedger.getLoanProduct().getName());
+    return new Loan(
+        loanLedger.getLoanLedgerId().getValue(),
+        loanLedger.getLoanProduct().getName(),
+        loanLedger.getNextRepaymentDate(),
+        loanLedger.isAutoDepositEnabled());
     //        loanLedger.getCreatedAt(),
     //        loanLedger.getLastRepaymentDate(),
     //        loanLedger.getTerm(),

--- a/loan-mate/src/main/java/com/fisa/bank/loan/persistence/repository/LoanRepositoryImpl.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/persistence/repository/LoanRepositoryImpl.java
@@ -3,12 +3,14 @@ package com.fisa.bank.loan.persistence.repository;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
 import com.fisa.bank.loan.application.model.Loan;
 import com.fisa.bank.loan.application.repository.LoanRepository;
 import com.fisa.bank.persistence.loan.entity.LoanLedger;
+import com.fisa.bank.persistence.loan.entity.id.LoanLedgerId;
 import com.fisa.bank.persistence.loan.repository.LoanLedgerRepository;
 import com.fisa.bank.persistence.user.entity.id.UserId;
 
@@ -37,5 +39,10 @@ public class LoanRepositoryImpl implements LoanRepository {
     //        loanLedger.getLastRepaymentDate(),
     //        loanLedger.getTerm(),
     //        loanLedger.getRepaymentStatus());
+  }
+
+  @Override
+  public Optional<Loan> findById(Long loanId) {
+    return loanLedgerRepository.findById(LoanLedgerId.of(loanId)).map(LoanRepositoryImpl::toDomain);
   }
 }


### PR DESCRIPTION
## 관련 이슈
- #38 

## 기능
- Service Layer에서 LoanLedger(Entity) 직접 의존하던 구조 제거
- Loan 도메인 모델에 필요한 필드(nextRepaymentDate, autoDepositEnabled) 확장