### PR TITLE
[FEAT] 선납 이득인 대출 리스트 조회 기능 추가

### DIFF
--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoansWithPrepaymentBenefitResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoansWithPrepaymentBenefitResponse.java
@@ -1,0 +1,17 @@
+package com.fisa.bank.loan.application.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.math.BigDecimal;
+
+@RequiredArgsConstructor
+@Getter
+public class LoansWithPrepaymentBenefitResponse {
+  private final String loanName;
+  private final BigDecimal benefit;
+
+  public static LoansWithPrepaymentBenefitResponse from(String loanName, BigDecimal benefit) {
+    return new LoansWithPrepaymentBenefitResponse(loanName, benefit);
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/model/InterestDetail.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/model/InterestDetail.java
@@ -1,14 +1,15 @@
 package com.fisa.bank.loan.application.model;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class InterestDetail {
-  private final LocalDateTime repaymentDate;
-  private final BigDecimal interest;
+  private LocalDateTime repaymentDate;
+  private BigDecimal interest;
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/model/InterestDetail.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/model/InterestDetail.java
@@ -1,0 +1,14 @@
+package com.fisa.bank.loan.application.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class InterestDetail {
+  private final LocalDateTime repaymentDate;
+  private final BigDecimal interest;
+}

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/model/PrepaymentInfo.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/model/PrepaymentInfo.java
@@ -1,16 +1,17 @@
 package com.fisa.bank.loan.application.model;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.util.List;
 
 @Builder
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class PrepaymentInfo {
-  private final Long loanLedgerId;
-  private final String loanProductName;
-  private final BigDecimal earlyRepayment;
-  private final List<InterestDetail> interestDetails;
+  private Long loanLedgerId;
+  private String loanProductName;
+  private BigDecimal earlyRepayment;
+  private List<InterestDetail> interestDetailResponses;
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/model/PrepaymentInfo.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/model/PrepaymentInfo.java
@@ -1,0 +1,16 @@
+package com.fisa.bank.loan.application.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Builder
+@Getter
+public class PrepaymentInfo {
+  private final Long loanLedgerId;
+  private final String loanProductName;
+  private final BigDecimal earlyRepayment;
+  private final List<InterestDetail> interestDetails;
+}

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -101,7 +101,7 @@ public class LoanService implements ManageLoanUseCase {
     List<PrepaymentInfo> prepaymentInfos = loanReader.findPrepaymentInfos();
 
     for (PrepaymentInfo prepaymentInfo : prepaymentInfos) {
-      List<InterestDetail> interestDetails = prepaymentInfo.getInterestDetails();
+      List<InterestDetail> interestDetails = prepaymentInfo.getInterestDetailResponses();
       BigDecimal earlyRepayment = prepaymentInfo.getEarlyRepayment();
 
       BigDecimal remainInterests =

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
@@ -11,8 +11,8 @@ import com.fisa.bank.common.application.service.CoreBankingClient;
 import com.fisa.bank.loan.application.exception.LoanLedgerNotFoundException;
 import com.fisa.bank.loan.application.model.Loan;
 import com.fisa.bank.loan.application.model.LoanDetail;
+import com.fisa.bank.loan.application.model.PrepaymentInfo;
 import com.fisa.bank.loan.application.repository.LoanRepository;
-import com.fisa.bank.persistence.loan.repository.LoanLedgerRepository;
 import com.fisa.bank.persistence.user.entity.id.UserId;
 
 @Component
@@ -21,7 +21,6 @@ import com.fisa.bank.persistence.user.entity.id.UserId;
 public class LoanReader {
   private final LoanRepository loanRepository;
   private final CoreBankingClient coreBankingClient;
-  private final LoanLedgerRepository loanLedgerRepository;
 
   public LoanDetail findLoanDetail(Long loanId) {
     String url = "/loans/ledger/" + loanId;
@@ -37,5 +36,11 @@ public class LoanReader {
     return loanRepository
         .findById(loanId)
         .orElseThrow(() -> new LoanLedgerNotFoundException(loanId));
+  }
+
+  public List<PrepaymentInfo> findPrepaymentInfos() {
+    String url = "/loans/prepayment-infos";
+
+    return coreBankingClient.fetchList(url, PrepaymentInfo.class);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
@@ -22,6 +22,8 @@ public class LoanReader {
   private final LoanRepository loanRepository;
   private final CoreBankingClient coreBankingClient;
 
+  private static final String PREPAYMENT_INFOS_URL = "/loans/prepayment-infos";
+
   public LoanDetail findLoanDetail(Long loanId) {
     String url = "/loans/ledger/" + loanId;
 
@@ -39,8 +41,6 @@ public class LoanReader {
   }
 
   public List<PrepaymentInfo> findPrepaymentInfos() {
-    String url = "/loans/prepayment-infos";
-
-    return coreBankingClient.fetchList(url, PrepaymentInfo.class);
+    return coreBankingClient.fetchList(PREPAYMENT_INFOS_URL, PrepaymentInfo.class);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/usecase/ManageLoanUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/usecase/ManageLoanUseCase.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.fisa.bank.loan.application.dto.response.LoanAutoDepositResponse;
 import com.fisa.bank.loan.application.dto.response.LoanDetailResponse;
 import com.fisa.bank.loan.application.dto.response.LoanListResponse;
+import com.fisa.bank.loan.application.dto.response.LoansWithPrepaymentBenefitResponse;
 
 public interface ManageLoanUseCase {
 
@@ -15,4 +16,6 @@ public interface ManageLoanUseCase {
   LoanAutoDepositResponse getAutoDeposit(Long loanId);
 
   void cancelLoan(Long loanId);
+
+  List<LoansWithPrepaymentBenefitResponse> getLoansWithPrepaymentBenefit();
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
@@ -15,6 +15,7 @@ import com.fisa.bank.common.presentation.response.code.ResponseCode;
 import com.fisa.bank.loan.application.dto.response.LoanAutoDepositResponse;
 import com.fisa.bank.loan.application.dto.response.LoanDetailResponse;
 import com.fisa.bank.loan.application.dto.response.LoanListResponse;
+import com.fisa.bank.loan.application.dto.response.LoansWithPrepaymentBenefitResponse;
 import com.fisa.bank.loan.application.usecase.ManageLoanUseCase;
 
 @RestController
@@ -52,5 +53,14 @@ public class LoanController {
   public void deleteLoan(@PathVariable("loanId") Long loanId) {
     log.info("대출 해지");
     manageLoanUseCase.cancelLoan(loanId);
+  }
+
+  @GetMapping("/prepayment-infos")
+  public ApiResponse<SuccessBody<List<LoansWithPrepaymentBenefitResponse>>>
+      getLoansWithPrepaymentBenefit() {
+    log.info("선납 이득인 대출 조회");
+    List<LoansWithPrepaymentBenefitResponse> loansWithPrepaymentBenefit =
+        manageLoanUseCase.getLoansWithPrepaymentBenefit();
+    return ApiResponseGenerator.success(ResponseCode.GET, loansWithPrepaymentBenefit);
   }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #10 

## 추가 사항
- 선납 이득인 대출의 이름과 이득이 얼마인지를 조회할 수 있는 API입니다.
- 중도 상환 수수료와 남은 기간 이자 합산 중 수수료가 더 적은 경우, 선납이 이득이라고 판단합니다.
