### PR TITLE
[FEAT] 클라이언트에게 jwt 토큰 발급 

### DIFF
--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/JwtTokenGenerator.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/JwtTokenGenerator.java
@@ -1,0 +1,73 @@
+package com.fisa.bank.common.application.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class JwtTokenGenerator {
+
+  @Value("${jwt.secret}")
+  private String jwtSecret;
+
+  @Value("${jwt.access-token-expiration:900000}") // 15분
+  private long accessTokenExpiration;
+
+  @Value("${jwt.refresh-token-expiration:604800000}") // 7일
+  private long refreshTokenExpiration;
+
+  /** Access Token 생성 */
+  public String generateAccessToken(Long userId) {
+    Instant now = Instant.now();
+    Instant expiration = now.plusMillis(accessTokenExpiration);
+
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("user_id", userId);
+    claims.put("token_type", "access");
+
+    return Jwts.builder()
+        .claims(claims)
+        .subject(String.valueOf(userId))
+        .issuedAt(Date.from(now))
+        .expiration(Date.from(expiration))
+        .id(UUID.randomUUID().toString())
+        .signWith(getSigningKey(), Jwts.SIG.HS256)
+        .compact();
+  }
+
+  /** Refresh Token 생성 */
+  public String generateRefreshToken(Long userId) {
+    Instant now = Instant.now();
+    Instant expiration = now.plusMillis(refreshTokenExpiration);
+
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("user_id", userId);
+    claims.put("token_type", "refresh");
+
+    return Jwts.builder()
+        .claims(claims)
+        .subject(String.valueOf(userId))
+        .issuedAt(Date.from(now))
+        .expiration(Date.from(expiration))
+        .id(UUID.randomUUID().toString())
+        .signWith(getSigningKey(), Jwts.SIG.HS256) // 최신 방식
+        .compact();
+  }
+
+  private SecretKey getSigningKey() {
+    return Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/JwtTokenGenerator.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/JwtTokenGenerator.java
@@ -67,7 +67,7 @@ public class JwtTokenGenerator {
         .compact();
   }
 
-  private SecretKey getSigningKey() {
+  public SecretKey getSigningKey() {
     return Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/JwtTokenValidator.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/JwtTokenValidator.java
@@ -1,6 +1,7 @@
 package com.fisa.bank.common.application.service;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,7 +37,7 @@ public class JwtTokenValidator {
 
       return claims;
 
-    } catch (Exception e) {
+    } catch (JwtException e) {
       log.warn("Access Token 검증 실패: {}", e.getMessage());
       throw new IllegalArgumentException("유효하지 않은 Access Token", e);
     }
@@ -69,7 +70,7 @@ public class JwtTokenValidator {
 
       return ((Number) userIdObj).longValue();
 
-    } catch (Exception e) {
+    } catch (JwtException e) {
       log.warn("Refresh Token 검증 실패: {}", e.getMessage());
       throw new IllegalArgumentException("유효하지 않은 Refresh Token", e);
     }

--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/JwtTokenValidator.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/JwtTokenValidator.java
@@ -2,22 +2,17 @@ package com.fisa.bank.common.application.service;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import java.nio.charset.StandardCharsets;
-
-import javax.crypto.SecretKey;
-
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class JwtTokenValidator {
 
-  @Value("${jwt.secret}")
-  private String jwtSecret;
+  private final JwtTokenGenerator jwtTokenGenerator;
 
   /**
    * Access Token 검증
@@ -29,7 +24,7 @@ public class JwtTokenValidator {
     try {
       Claims claims =
           Jwts.parser()
-              .verifyWith(getSigningKey())
+              .verifyWith(jwtTokenGenerator.getSigningKey())
               .build()
               .parseSignedClaims(accessToken)
               .getPayload();
@@ -57,7 +52,7 @@ public class JwtTokenValidator {
     try {
       Claims claims =
           Jwts.parser()
-              .verifyWith(getSigningKey())
+              .verifyWith(jwtTokenGenerator.getSigningKey())
               .build()
               .parseSignedClaims(refreshToken)
               .getPayload();
@@ -78,9 +73,5 @@ public class JwtTokenValidator {
       log.error("Refresh Token 검증 실패: {}", e.getMessage());
       throw new IllegalArgumentException("유효하지 않은 Refresh Token", e);
     }
-  }
-
-  private SecretKey getSigningKey() {
-    return Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/JwtTokenValidator.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/JwtTokenValidator.java
@@ -37,7 +37,7 @@ public class JwtTokenValidator {
       return claims;
 
     } catch (Exception e) {
-      log.error("Access Token 검증 실패: {}", e.getMessage());
+      log.warn("Access Token 검증 실패: {}", e.getMessage());
       throw new IllegalArgumentException("유효하지 않은 Access Token", e);
     }
   }
@@ -70,7 +70,7 @@ public class JwtTokenValidator {
       return ((Number) userIdObj).longValue();
 
     } catch (Exception e) {
-      log.error("Refresh Token 검증 실패: {}", e.getMessage());
+      log.warn("Refresh Token 검증 실패: {}", e.getMessage());
       throw new IllegalArgumentException("유효하지 않은 Refresh Token", e);
     }
   }

--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/JwtTokenValidator.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/JwtTokenValidator.java
@@ -1,239 +1,86 @@
 package com.fisa.bank.common.application.service;
 
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
-import io.jsonwebtoken.security.SignatureException;
-import jakarta.annotation.PostConstruct;
+import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 
-import java.math.BigInteger;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.PublicKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.RSAPublicKeySpec;
-import java.time.Duration;
-import java.util.Base64;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.nio.charset.StandardCharsets;
+
+import javax.crypto.SecretKey;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Service
 public class JwtTokenValidator {
 
-  /** jwks-uri 를 발급받는 외부의 서버 uri */
-  @Value("${jwt.issuer-uri}")
-  private String issuerUri;
+  @Value("${jwt.secret}")
+  private String jwtSecret;
 
-  /** yml 에서 직접 정의한 JWKS URI (있으면 무조건 우선 사용) */
-  @Value("${jwt.jwk-set-uri:#{null}}")
-  private String jwkSetUri;
-
-  private final WebClient webClient = WebClient.create();
-  private final ObjectMapper mapper = new ObjectMapper();
-
-  /** kid → PublicKey 캐시 */
-  private final Map<String, PublicKey> keyCache = new ConcurrentHashMap<>();
-
-  /** 실제 사용 중인 JWKS URI */
-  private volatile String jwksUri;
-
-  /** 마지막 JWKS 성공 로딩 시간 */
-  private volatile long lastJwksLoadedAt = 0L;
-
-  /** JWKS 재로딩 간격 (100분) */
-  private static final long JWKS_RELOAD_INTERVAL = Duration.ofMinutes(100).toMillis();
-
-  @PostConstruct
-  public void init() {
-    if (issuerUri == null || issuerUri.isBlank()) {
-      throw new IllegalStateException("jwt.issuer-uri 설정이 필요합니다.");
-    }
-
-    // yml에 명시된 JWKS URI가 있으면 최우선 사용
-    if (jwkSetUri != null && !jwkSetUri.isBlank()) {
-      this.jwksUri = jwkSetUri;
-      log.info("미리 정의된 JWKS URI 사용: {}", jwksUri);
-    } else {
-      // 없다면 issuer 기반으로 lazy 로딩
-      log.info("JWKS URI 는 issuer 기반으로 lazy 로딩 issuer={}", issuerUri);
-    }
-  }
-
-  // JWT 검증
-  public Claims validateToken(String token) {
+  /**
+   * Access Token 검증
+   *
+   * @param accessToken Access Token
+   * @return Claims
+   */
+  public Claims validateAccessToken(String accessToken) {
     try {
-      String kid = extractKid(token);
+      Claims claims =
+          Jwts.parser()
+              .verifyWith(getSigningKey())
+              .build()
+              .parseSignedClaims(accessToken)
+              .getPayload();
 
-      // 키 캐시에 없는 경우 또는 재로딩 시간이 된 경우
-      PublicKey key = keyCache.get(kid);
-      if (key == null || needReload()) {
-        tryReloadJwks();
-        key = keyCache.get(kid);
+      String tokenType = (String) claims.get("token_type");
+      if (!"access".equals(tokenType)) {
+        throw new IllegalArgumentException("유효하지 않은 토큰 타입");
       }
 
-      if (key == null) {
-        throw new JwtException("kid=" + kid + " 에 해당하는 공개키 없음");
-      }
+      return claims;
 
-      return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
-
-    } catch (ExpiredJwtException e) {
-      log.debug("토큰 만료: {}", e.getMessage());
-      throw e;
-    } catch (SignatureException e) {
-      log.debug("서명 불일치: {}", e.getMessage());
-      throw e;
-    } catch (MalformedJwtException e) {
-      log.debug("JWT 형식 오류: {}", e.getMessage());
-      throw e;
-    } catch (UnsupportedJwtException e) {
-      log.debug("지원하지 않는 JWT: {}", e.getMessage());
-      throw e;
+    } catch (Exception e) {
+      log.error("Access Token 검증 실패: {}", e.getMessage());
+      throw new IllegalArgumentException("유효하지 않은 Access Token", e);
     }
   }
 
-  /** 내부 메서드 */
-
-  /** JWT 헤더에서 kid 추출 */
-  private String extractKid(String token) {
+  /**
+   * Refresh Token 검증 및 userId 추출
+   *
+   * @param refreshToken Refresh Token
+   * @return userId
+   */
+  public Long validateRefreshTokenAndGetUserId(String refreshToken) {
     try {
-      String[] parts = token.split("\\.");
-      if (parts.length != 3) {
-        throw new MalformedJwtException("JWT 토큰은 세 부분으로 구성되어야 합니다.");
+      Claims claims =
+          Jwts.parser()
+              .verifyWith(getSigningKey())
+              .build()
+              .parseSignedClaims(refreshToken)
+              .getPayload();
+
+      String tokenType = (String) claims.get("token_type");
+      if (!"refresh".equals(tokenType)) {
+        throw new IllegalArgumentException("유효하지 않은 토큰 타입");
       }
-      String headerPart = parts[0];
-      byte[] decoded = Base64.getUrlDecoder().decode(headerPart);
-      Map<String, Object> header = mapper.readValue(decoded, Map.class);
 
-      Object kid = header.get("kid");
-      if (kid == null) {
-        throw new JwtException("JWT 헤더에 kid가 없습니다.");
+      Object userIdObj = claims.get("user_id");
+      if (userIdObj == null) {
+        throw new IllegalArgumentException("user_id가 없습니다");
       }
 
-      return kid.toString();
+      return ((Number) userIdObj).longValue();
 
-    } catch (IllegalArgumentException // Base64 decode 실패
-        | java.io.IOException e) {
-      throw new JwtException("JWT 헤더에서 kid 추출 실패", e);
+    } catch (Exception e) {
+      log.error("Refresh Token 검증 실패: {}", e.getMessage());
+      throw new IllegalArgumentException("유효하지 않은 Refresh Token", e);
     }
   }
 
-  /** 재로딩 기간 지났는지 */
-  private boolean needReload() {
-    long now = System.currentTimeMillis();
-    return (now - lastJwksLoadedAt) >= JWKS_RELOAD_INTERVAL;
-  }
-
-  /** JWKS 로딩 */
-  private synchronized void tryReloadJwks() {
-    try {
-      // config 의 jwk-set-uri 우선 사용
-      if (jwkSetUri != null && !jwkSetUri.isBlank()) {
-        log.debug("JWKS 로딩 시도: configured jwk-set-uri={}", jwkSetUri);
-        Map<String, PublicKey> refreshed = loadAllKeysFromJwks(jwkSetUri);
-        applyNewKeys(refreshed);
-        return;
-      }
-
-      // issuer 기반으로 jwks_uri 조회
-      log.warn("configured jwk-set-uri 없음. issuer에서 jwks_uri 획득 시도…");
-
-      this.jwksUri = fetchJwksUriFromIssuer(issuerUri);
-      log.info("issuer 기반 최신 jwks_uri 획득: {}", jwksUri);
-
-      Map<String, PublicKey> refreshed = loadAllKeysFromJwks(jwksUri);
-      applyNewKeys(refreshed);
-
-    } catch (Exception ex) {
-      log.error("JWKS 로딩 실패. 기존 keyCache 유지. reason={}", ex.getMessage());
-    }
-  }
-
-  /** openid-configuration에서 jwks_uri 획득 */
-  private String fetchJwksUriFromIssuer(String issuer) {
-    Map<String, Object> config =
-        webClient
-            .get()
-            .uri(issuer + "/.well-known/openid-configuration")
-            .retrieve()
-            .bodyToMono(Map.class)
-            .block();
-
-    if (config == null || config.get("jwks_uri") == null) {
-      throw new IllegalStateException("issuer에서 jwks_uri 가져오기 실패");
-    }
-
-    return config.get("jwks_uri").toString();
-  }
-
-  /** JWKS 전체 키 로딩 */
-  @SuppressWarnings("unchecked")
-  private Map<String, PublicKey> loadAllKeysFromJwks(String uri) {
-    try {
-      Map<String, Object> jwks = webClient.get().uri(uri).retrieve().bodyToMono(Map.class).block();
-
-      if (jwks == null || !jwks.containsKey("keys")) {
-        throw new IllegalStateException("JWKS 응답 형식 오류");
-      }
-
-      List<Map<String, Object>> keys = (List<Map<String, Object>>) jwks.get("keys");
-      Map<String, PublicKey> result = new ConcurrentHashMap<>();
-
-      for (Map<String, Object> k : keys) {
-        if (!"RSA".equals(k.get("kty"))) continue;
-
-        String kid = (String) k.get("kid");
-        String n = (String) k.get("n");
-        String e = (String) k.get("e");
-
-        if (kid == null || n == null || e == null) {
-          log.warn("JWKS 키 정보 부족. skip. kid={}", kid);
-          continue;
-        }
-
-        // 여기서 checked exception 발생 → try/catch로 처리됨
-        PublicKey pk = createRsaPublicKey(n, e);
-        result.put(kid, pk);
-      }
-
-      return result;
-
-    } catch (Exception ex) {
-      // RSA 키 생성 실패, WebClient 오류 등 모든 checked exception 런타임으로 래핑
-      throw new IllegalStateException("JWKS 로딩 및 RSA 키 생성 중 오류 발생: " + ex.getMessage(), ex);
-    }
-  }
-
-  private PublicKey createRsaPublicKey(String n, String e)
-      throws NoSuchAlgorithmException, InvalidKeySpecException {
-    BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(n));
-    BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(e));
-    return KeyFactory.getInstance("RSA").generatePublic(new RSAPublicKeySpec(modulus, exponent));
-  }
-
-  /** keyCache 업데이트 */
-  private void applyNewKeys(Map<String, PublicKey> newKeys) {
-    if (newKeys.isEmpty()) {
-      log.warn("JWKS 로딩 성공했지만 key 없음. 기존 캐시 유지.");
-      return;
-    }
-
-    keyCache.clear();
-    keyCache.putAll(newKeys);
-    lastJwksLoadedAt = System.currentTimeMillis();
-
-    log.info("JWKS 업데이트 완료. key count={}", keyCache.size());
+  private SecretKey getSigningKey() {
+    return Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/common/application/util/RequesterInfo.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/util/RequesterInfo.java
@@ -1,0 +1,8 @@
+package com.fisa.bank.common.application.util;
+
+public interface RequesterInfo {
+
+  Long getServiceUserId();
+
+  Long getCoreBankingUserId();
+}

--- a/loan-mate/src/main/java/com/fisa/bank/common/config/security/CustomOAuth2SuccessHandler.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/config/security/CustomOAuth2SuccessHandler.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
@@ -39,6 +40,9 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
   private final JwtTokenGenerator jwtTokenGenerator;
   private final RefreshTokenRepository refreshTokenRepository;
   private final UserAuthRepository userAuthRepository;
+
+  @Value("${jwt.refresh-token-expiration}")
+  private Long refreshTokenTime;
 
   @Override
   public void onAuthenticationSuccess(
@@ -78,9 +82,8 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
     // 우리 서버의 JWT 토큰 생성
     String accessToken = jwtTokenGenerator.generateAccessToken(serviceUserId);
     String refreshToken = jwtTokenGenerator.generateRefreshToken(serviceUserId);
-
     // Refresh Token DB에 저장 (7일 후 만료)
-    Instant refreshTokenExpiry = Instant.now().plusMillis(604800000L);
+    Instant refreshTokenExpiry = Instant.now().plusMillis(refreshTokenTime);
     refreshTokenRepository.save(serviceUserId, refreshToken, refreshTokenExpiry);
 
     // 응답 생성

--- a/loan-mate/src/main/java/com/fisa/bank/common/config/security/CustomOAuth2SuccessHandler.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/config/security/CustomOAuth2SuccessHandler.java
@@ -6,19 +6,25 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
 
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fisa.bank.common.application.service.CoreBankingClient;
+import com.fisa.bank.common.application.service.JwtTokenGenerator;
 import com.fisa.bank.user.application.dto.LoginResponse;
 import com.fisa.bank.user.application.dto.UserInfoResponse;
+import com.fisa.bank.user.application.repository.RefreshTokenRepository;
+import com.fisa.bank.user.application.repository.UserAuthRepository;
 import com.fisa.bank.user.application.usecase.SyncCoreBankUserUseCase;
 
 @Slf4j
@@ -30,32 +36,59 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
   private final SyncCoreBankUserUseCase syncCoreBankUserUseCase;
   private final OAuth2AuthorizedClientService authorizedClientService;
   private final ObjectMapper objectMapper;
+  private final JwtTokenGenerator jwtTokenGenerator;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final UserAuthRepository userAuthRepository;
 
   @Override
   public void onAuthenticationSuccess(
       HttpServletRequest request, HttpServletResponse response, Authentication authentication)
       throws IOException {
 
-    UserInfoResponse me = coreBankingClient.fetchOne("users/me", UserInfoResponse.class);
+    // 코어 뱅킹 사용자 정보 조회 및 동기화
+    UserInfoResponse me = coreBankingClient.fetchOne("/users/me", UserInfoResponse.class);
     syncCoreBankUserUseCase.sync(me);
 
-    // OAuth2 토큰 가져오기
+    // serviceUserId 조회
+    Long serviceUserId =
+        userAuthRepository
+            .findByCoreBankingUserId(me.userId())
+            .orElseThrow(() -> new IllegalStateException("사용자 동기화 후 매핑 정보를 찾을 수 없습니다."))
+            .getServiceUserId();
+
+    // OAuth2 토큰 저장 (코어 뱅킹 서버용)
     OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
     OAuth2AuthorizedClient authorizedClient =
         authorizedClientService.loadAuthorizedClient(
             oauthToken.getAuthorizedClientRegistrationId(), oauthToken.getName());
 
-    String accessToken = authorizedClient.getAccessToken().getTokenValue();
-    String refreshToken =
-        authorizedClient.getRefreshToken() != null
-            ? authorizedClient.getRefreshToken().getTokenValue()
-            : null;
+    // serviceUserId를 principal name으로 사용하도록 새로운 OAuth2User와 인증 객체 생성
+    DefaultOAuth2User newPrincipal =
+        new DefaultOAuth2User(
+            Collections.emptyList(),
+            Collections.singletonMap("sub", serviceUserId.toString()),
+            "sub");
+
+    OAuth2AuthenticationToken newAuthToken =
+        new OAuth2AuthenticationToken(
+            newPrincipal, Collections.emptyList(), oauthToken.getAuthorizedClientRegistrationId());
+
+    authorizedClientService.saveAuthorizedClient(authorizedClient, newAuthToken);
+
+    // 우리 서버의 JWT 토큰 생성
+    String accessToken = jwtTokenGenerator.generateAccessToken(serviceUserId);
+    String refreshToken = jwtTokenGenerator.generateRefreshToken(serviceUserId);
+
+    // Refresh Token DB에 저장 (7일 후 만료)
+    Instant refreshTokenExpiry = Instant.now().plusMillis(604800000L);
+    refreshTokenRepository.save(serviceUserId, refreshToken, refreshTokenExpiry);
 
     // 응답 생성
-    LoginResponse loginResponse = new LoginResponse(accessToken, refreshToken, me.userId());
+    LoginResponse loginResponse = new LoginResponse(accessToken, refreshToken, serviceUserId);
+    String jsonResponse = objectMapper.writeValueAsString(loginResponse);
 
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     response.setCharacterEncoding("UTF-8");
-    response.getWriter().write(objectMapper.writeValueAsString(loginResponse));
+    response.getWriter().write(jsonResponse);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/common/config/security/JwtAuthenticationFilter.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/config/security/JwtAuthenticationFilter.java
@@ -40,7 +40,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     if (token != null) {
       try {
-        Claims claims = jwtTokenValidator.validateToken(token);
+        Claims claims = jwtTokenValidator.validateAccessToken(token);
         String userId = claims.getSubject();
 
         UsernamePasswordAuthenticationToken authentication =

--- a/loan-mate/src/main/java/com/fisa/bank/common/config/security/JwtAuthenticationFilter.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/config/security/JwtAuthenticationFilter.java
@@ -12,7 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.util.Collections;
 
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
@@ -41,10 +40,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     if (token != null) {
       try {
         Claims claims = jwtTokenValidator.validateAccessToken(token);
-        String userId = claims.getSubject();
+        Long userId = Long.valueOf(claims.getSubject());
 
-        UsernamePasswordAuthenticationToken authentication =
-            new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+        ServiceUserAuthentication authentication =
+            new ServiceUserAuthentication(userId, Collections.emptyList());
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/loan-mate/src/main/java/com/fisa/bank/common/config/security/SecurityConfig.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/config/security/SecurityConfig.java
@@ -86,8 +86,14 @@ public class SecurityConfig {
     http.securityMatcher("/api/**")
         .csrf(AbstractHttpConfigurer::disable)
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers("/api/auth/refresh", "/api/login/**")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
     return http.build();
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/common/config/security/ServiceUserAuthentication.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/config/security/ServiceUserAuthentication.java
@@ -1,0 +1,36 @@
+package com.fisa.bank.common.config.security;
+
+import lombok.Getter;
+
+import java.util.Collection;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * 서비스 사용자 인증 객체
+ *
+ * <p>JWT 토큰 기반 인증에서 사용되며, 서비스 사용자 ID를 포함합니다.
+ */
+@Getter
+public class ServiceUserAuthentication extends AbstractAuthenticationToken {
+
+  private final Long userId;
+
+  public ServiceUserAuthentication(
+      Long userId, Collection<? extends GrantedAuthority> authorities) {
+    super(authorities);
+    this.userId = userId;
+    setAuthenticated(true);
+  }
+
+  @Override
+  public Object getCredentials() {
+    return null;
+  }
+
+  @Override
+  public Object getPrincipal() {
+    return userId;
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/common/presentation/util/SpringRequesterInfo.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/presentation/util/SpringRequesterInfo.java
@@ -1,0 +1,51 @@
+package com.fisa.bank.common.presentation.util;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import com.fisa.bank.common.application.util.RequesterInfo;
+import com.fisa.bank.common.config.security.ServiceUserAuthentication;
+import com.fisa.bank.user.application.model.UserAuth;
+import com.fisa.bank.user.application.repository.UserAuthRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SpringRequesterInfo implements RequesterInfo {
+
+  private final UserAuthRepository userAuthRepository;
+  private final Map<Long, Long> serviceToCoreBankingCache = new ConcurrentHashMap<>();
+
+  @Override
+  public Long getServiceUserId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    if (authentication == null) {
+      throw new IllegalStateException("SecurityContext authentication 없음");
+    }
+
+    if (!(authentication instanceof ServiceUserAuthentication serviceAuth)) {
+      throw new IllegalStateException("SecurityContext에서 ServiceUserAuthentication 찾을 수 없음");
+    }
+
+    return serviceAuth.getUserId();
+  }
+
+  @Override
+  public Long getCoreBankingUserId() {
+    Long serviceUserId = getServiceUserId();
+
+    return serviceToCoreBankingCache.computeIfAbsent(
+        serviceUserId,
+        id ->
+            userAuthRepository
+                .findByServiceUserId(id)
+                .map(UserAuth::getCoreBankingUserId)
+                .orElseThrow(() -> new IllegalStateException("코어뱅킹 userId 찾을 수 없음")));
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/dto/RefreshTokenRequest.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/dto/RefreshTokenRequest.java
@@ -1,0 +1,3 @@
+package com.fisa.bank.user.application.dto;
+
+public record RefreshTokenRequest(String refreshToken) {}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/dto/RefreshTokenResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/dto/RefreshTokenResponse.java
@@ -1,0 +1,3 @@
+package com.fisa.bank.user.application.dto;
+
+public record RefreshTokenResponse(String accessToken) {}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/dto/RefreshTokenResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/dto/RefreshTokenResponse.java
@@ -1,3 +1,3 @@
 package com.fisa.bank.user.application.dto;
 
-public record RefreshTokenResponse(String accessToken) {}
+public record RefreshTokenResponse(String accessToken, String refreshToken) {}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/repository/RefreshTokenRepository.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/repository/RefreshTokenRepository.java
@@ -11,7 +11,7 @@ public interface RefreshTokenRepository {
 
   Optional<Long> findUserIdByToken(String token);
 
-  void deleteByUserId(Long userId);
+  void deleteByToken(String refreshToken);
 
   boolean existsByToken(String token);
 }

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/repository/RefreshTokenRepository.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/repository/RefreshTokenRepository.java
@@ -1,0 +1,17 @@
+package com.fisa.bank.user.application.repository;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+
+  void save(Long userId, String token, Instant expiresAt);
+
+  Optional<String> findByUserId(Long userId);
+
+  Optional<Long> findUserIdByToken(String token);
+
+  void deleteByUserId(Long userId);
+
+  boolean existsByToken(String token);
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultUpdateTokenUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultUpdateTokenUseCase.java
@@ -1,0 +1,53 @@
+package com.fisa.bank.user.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Instant;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fisa.bank.common.application.service.JwtTokenGenerator;
+import com.fisa.bank.common.application.service.JwtTokenValidator;
+import com.fisa.bank.user.application.dto.RefreshTokenResponse;
+import com.fisa.bank.user.application.repository.RefreshTokenRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DefaultUpdateTokenUseCase implements UpdateTokenUseCase {
+
+  private final JwtTokenValidator jwtTokenValidator;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final JwtTokenGenerator jwtTokenGenerator;
+
+  @Value("${jwt.refresh-token-expiration:604800000}")
+  private long refreshTokenExpiration;
+
+  @Override
+  public RefreshTokenResponse execute(String refreshToken) {
+    log.info("토큰 갱신 요청. refreshToken: {}", refreshToken);
+
+    Long userId = jwtTokenValidator.validateRefreshTokenAndGetUserId(refreshToken);
+    log.info("Refresh Token 검증 성공. userId: {}", userId);
+
+    if (!refreshTokenRepository.existsByToken(refreshToken)) {
+      log.warn("DB에 저장되지 않은 Refresh Token");
+      throw new IllegalArgumentException("유효하지 않은 Refresh Token");
+    }
+
+    refreshTokenRepository.deleteByToken(refreshToken);
+    log.info("기존 Refresh Token 삭제 완료. userId: {}", userId);
+
+    String newAccessToken = jwtTokenGenerator.generateAccessToken(userId);
+    String newRefreshToken = jwtTokenGenerator.generateRefreshToken(userId);
+    Instant refreshTokenExpiry = Instant.now().plusMillis(refreshTokenExpiration);
+    refreshTokenRepository.save(userId, newRefreshToken, refreshTokenExpiry);
+    log.info("새로운 Access/Refresh Token 발급 및 저장 완료. userId: {}", userId);
+
+    return new RefreshTokenResponse(newAccessToken, newRefreshToken);
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultUpdateTokenUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultUpdateTokenUseCase.java
@@ -29,7 +29,7 @@ public class DefaultUpdateTokenUseCase implements UpdateTokenUseCase {
 
   @Override
   public RefreshTokenResponse execute(String refreshToken) {
-    log.info("토큰 갱신 요청. refreshToken: {}", refreshToken);
+    log.info("토큰 갱신 요청");
 
     Long userId = jwtTokenValidator.validateRefreshTokenAndGetUserId(refreshToken);
     log.info("Refresh Token 검증 성공. userId: {}", userId);

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/UpdateTokenUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/UpdateTokenUseCase.java
@@ -1,0 +1,7 @@
+package com.fisa.bank.user.application.usecase;
+
+import com.fisa.bank.user.application.dto.RefreshTokenResponse;
+
+public interface UpdateTokenUseCase {
+  RefreshTokenResponse execute(String refreshToken);
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/RefreshTokenEntity.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/entity/RefreshTokenEntity.java
@@ -1,0 +1,49 @@
+package com.fisa.bank.user.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class RefreshTokenEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private Long userId;
+
+  @Column(nullable = false, unique = true, length = 500)
+  private String token;
+
+  @Column(nullable = false)
+  private Instant expiresAt;
+
+  @Column(nullable = false)
+  private Instant createdAt;
+
+  public static RefreshTokenEntity create(Long userId, String token, Instant expiresAt) {
+    return RefreshTokenEntity.builder()
+        .userId(userId)
+        .token(token)
+        .expiresAt(expiresAt)
+        .createdAt(Instant.now())
+        .build();
+  }
+
+  public boolean isExpired() {
+    return Instant.now().isAfter(expiresAt);
+  }
+
+  public void updateToken(String newToken, Instant newExpiresAt) {
+    this.token = newToken;
+    this.expiresAt = newExpiresAt;
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/RefreshTokenJpaRepository.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/RefreshTokenJpaRepository.java
@@ -13,4 +13,6 @@ public interface RefreshTokenJpaRepository extends JpaRepository<RefreshTokenEnt
   Optional<RefreshTokenEntity> findByUserId(Long userId);
 
   void deleteByUserId(Long userId);
+
+  void deleteByToken(String refreshToken);
 }

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/RefreshTokenJpaRepository.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/RefreshTokenJpaRepository.java
@@ -1,0 +1,16 @@
+package com.fisa.bank.user.persistence.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.fisa.bank.user.persistence.entity.RefreshTokenEntity;
+
+public interface RefreshTokenJpaRepository extends JpaRepository<RefreshTokenEntity, Long> {
+
+  Optional<RefreshTokenEntity> findByToken(String token);
+
+  Optional<RefreshTokenEntity> findByUserId(Long userId);
+
+  void deleteByUserId(Long userId);
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/RefreshTokenRepositoryImpl.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/RefreshTokenRepositoryImpl.java
@@ -46,9 +46,8 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
   }
 
   @Override
-  @Transactional
-  public void deleteByUserId(Long userId) {
-    jpaRepository.deleteByUserId(userId);
+  public void deleteByToken(String refreshToken) {
+    jpaRepository.deleteByToken(refreshToken);
   }
 
   @Override

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/RefreshTokenRepositoryImpl.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/RefreshTokenRepositoryImpl.java
@@ -1,0 +1,58 @@
+package com.fisa.bank.user.persistence.repository;
+
+import lombok.RequiredArgsConstructor;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fisa.bank.user.application.repository.RefreshTokenRepository;
+import com.fisa.bank.user.persistence.entity.RefreshTokenEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
+
+  private final RefreshTokenJpaRepository jpaRepository;
+
+  @Override
+  @Transactional
+  public void save(Long userId, String token, Instant expiresAt) {
+    Optional<RefreshTokenEntity> existing = jpaRepository.findByUserId(userId);
+
+    if (existing.isPresent()) {
+      // 기존 토큰 업데이트
+      existing.get().updateToken(token, expiresAt);
+    } else {
+      // 새로운 토큰 생성
+      RefreshTokenEntity entity = RefreshTokenEntity.create(userId, token, expiresAt);
+      jpaRepository.save(entity);
+    }
+  }
+
+  @Override
+  public Optional<String> findByUserId(Long userId) {
+    return jpaRepository.findByUserId(userId).map(RefreshTokenEntity::getToken);
+  }
+
+  @Override
+  public Optional<Long> findUserIdByToken(String token) {
+    return jpaRepository
+        .findByToken(token)
+        .filter(entity -> !entity.isExpired())
+        .map(RefreshTokenEntity::getUserId);
+  }
+
+  @Override
+  @Transactional
+  public void deleteByUserId(Long userId) {
+    jpaRepository.deleteByUserId(userId);
+  }
+
+  @Override
+  public boolean existsByToken(String token) {
+    return jpaRepository.findByToken(token).map(entity -> !entity.isExpired()).orElse(false);
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
@@ -1,17 +1,65 @@
 package com.fisa.bank.user.presentation.controller;
 
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fisa.bank.common.application.service.JwtTokenGenerator;
+import com.fisa.bank.common.application.service.JwtTokenValidator;
+import com.fisa.bank.user.application.dto.RefreshTokenRequest;
+import com.fisa.bank.user.application.dto.RefreshTokenResponse;
+import com.fisa.bank.user.application.repository.RefreshTokenRepository;
+
+@Slf4j
 @RestController
+@RequiredArgsConstructor
 public class AuthController {
+
+  private final JwtTokenGenerator jwtTokenGenerator;
+  private final JwtTokenValidator jwtTokenValidator;
+  private final RefreshTokenRepository refreshTokenRepository;
 
   @GetMapping("/api/login")
   public void login(HttpServletResponse response) throws IOException {
     response.sendRedirect("/oauth2/authorization/loan-mate");
+  }
+
+  @PostMapping("/api/auth/refresh")
+  public ResponseEntity<RefreshTokenResponse> refresh(@RequestBody RefreshTokenRequest request) {
+    try {
+      log.info("토큰 갱신 요청. refreshToken: {}", request.refreshToken());
+
+      // Refresh Token 검증 및 userId 추출
+      Long userId = jwtTokenValidator.validateRefreshTokenAndGetUserId(request.refreshToken());
+      log.info("Refresh Token 검증 성공. userId: {}", userId);
+
+      // DB에서 Refresh Token 확인
+      if (!refreshTokenRepository.existsByToken(request.refreshToken())) {
+        log.warn("DB에 저장되지 않은 Refresh Token");
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+      }
+
+      // 새로운 Access Token 발급
+      String newAccessToken = jwtTokenGenerator.generateAccessToken(userId);
+      log.info("새로운 Access Token 발급 완료. userId: {}", userId);
+
+      return ResponseEntity.ok(new RefreshTokenResponse(newAccessToken));
+
+    } catch (IllegalArgumentException e) {
+      log.error("Refresh Token 검증 실패: {}", e.getMessage());
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    } catch (Exception e) {
+      log.error("토큰 갱신 중 예외 발생: {}", e.getMessage(), e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
@@ -41,7 +41,7 @@ public class AuthController {
   @PostMapping("/api/auth/refresh")
   public ResponseEntity<RefreshTokenResponse> refresh(@RequestBody RefreshTokenRequest request) {
     try {
-      log.info("토큰 갱신 요청. refreshToken: {}", request.refreshToken());
+      log.info("토큰 갱신 요청");
 
       // Refresh Token 검증 및 userId 추출
       Long userId = jwtTokenValidator.validateRefreshTokenAndGetUserId(request.refreshToken());

--- a/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
@@ -67,10 +67,10 @@ public class AuthController {
       return ResponseEntity.ok(new RefreshTokenResponse(newAccessToken, newRefreshToken));
 
     } catch (IllegalArgumentException e) {
-      log.error("Refresh Token 검증 실패: {}", e.getMessage());
+      log.warn("Refresh Token 검증 실패: {}", e.getMessage());
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     } catch (Exception e) {
-      log.error("토큰 갱신 중 예외 발생: {}", e.getMessage(), e);
+      log.warn("토큰 갱신 중 예외 발생: {}", e.getMessage(), e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }

--- a/loan-mate/src/main/resources/application-auth.yml
+++ b/loan-mate/src/main/resources/application-auth.yml
@@ -1,6 +1,9 @@
 jwt:
   issuer-uri: ${ISSUER_URL}
   jwk-set-uri: ${JWKS_URI}
+  secret: ${JWT_SECRET}
+  access-token-expiration: 900000 # 15분 (밀리초)
+  refresh-token-expiration: 604800000 # 7일 (밀리초)
 
 core-bank:
   api-url: ${CORE_BANKING_API_URL}

--- a/loan-mate/src/main/resources/application-auth.yml
+++ b/loan-mate/src/main/resources/application-auth.yml
@@ -1,6 +1,4 @@
 jwt:
-  issuer-uri: ${ISSUER_URL}
-  jwk-set-uri: ${JWKS_URI}
   secret: ${JWT_SECRET}
   access-token-expiration: 900000 # 15분 (밀리초)
   refresh-token-expiration: 604800000 # 7일 (밀리초)


### PR DESCRIPTION
## 관련 이슈 
- #42 

## 기능 
- 사용자에게 jwt 토큰 발급 (액세스 토큰, 리프레시 토큰)
- 액세스 토큰 만료 시 /api/auth/refresh 로 요청 (request body로 리프레시 토큰) 하면 새로운 액세스 토큰 발급 
- 새로운 인증 객체를 만들어서 principal 에 저장 -> 추후, 코어뱅킹 액세스 토큰을 찾을 때, 이 principal 로 찾음 (추후 캐싱?)
- localhost:8081/api/login 을 해서 받은 액세스 토큰으로 비즈니스 로직 api 에 요청을 보내면 알아서 코어뱅킹에 요청을 보냄 

## 추후 로그인 관련 개발해야 할 기능
- requesterInfo로 비즈니스 로직에서 corebanking id, service id를 조회할 수 있게 구현 
- 캐싱?
- 로그아웃

## 공유사항
- 원래 코어뱅킹 액세스 토큰을 사용하려고 했지만, 리프레시 토큰으로 액세스 토큰을 다시 받아오는 것에 실패. 인증 서버에서 oauth2로그인 후, 다시 받아오려면 인증 코드 등 여러 과정을 거쳐야 해 서비스용 액세스 토큰 발급으로 변경