### PR TITLE
[FEAT] 로그아웃 기능 구현 

### DIFF
--- a/loan-mate/src/main/java/com/fisa/bank/user/application/repository/RefreshTokenRepository.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/repository/RefreshTokenRepository.java
@@ -1,17 +1,14 @@
 package com.fisa.bank.user.application.repository;
 
 import java.time.Instant;
-import java.util.Optional;
 
 public interface RefreshTokenRepository {
 
   void save(Long userId, String token, Instant expiresAt);
 
-  Optional<String> findByUserId(Long userId);
-
-  Optional<Long> findUserIdByToken(String token);
-
   void deleteByToken(String refreshToken);
 
   boolean existsByToken(String token);
+
+  void deleteByUserId(Long UserId);
 }

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultLogoutUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultLogoutUseCase.java
@@ -1,0 +1,45 @@
+package com.fisa.bank.user.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fisa.bank.common.application.util.RequesterInfo;
+import com.fisa.bank.user.application.repository.RefreshTokenRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DefaultLogoutUseCase implements LogoutUseCase {
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final RequesterInfo requesterInfo;
+
+  @Override
+  public void execute() {
+    log.info("로그아웃 요청");
+
+    // SecurityContext 에서 현재 인증된 유저 ID 가져오기
+    Long userId = requesterInfo.getServiceUserId();
+
+    if (userId == null) {
+      log.warn("로그아웃 실패: 인증된 사용자 정보 없음");
+      return;
+    }
+
+    log.info("로그아웃 진행 userId={}", userId);
+
+    // 해당 유저의 Refresh Token 삭제
+    String refreshToken = refreshTokenRepository.findByUserId(userId).orElse(null);
+    if (refreshToken == null) {
+      log.info("삭제할 RefreshToken 없음");
+      return;
+    }
+
+    refreshTokenRepository.deleteByToken(refreshToken);
+
+    log.info("유저 {}의 RefreshToken 삭제 완료", userId);
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultLogoutUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultLogoutUseCase.java
@@ -29,16 +29,7 @@ public class DefaultLogoutUseCase implements LogoutUseCase {
       return;
     }
 
-    log.info("로그아웃 진행 userId={}", userId);
-
-    // 해당 유저의 Refresh Token 삭제
-    String refreshToken = refreshTokenRepository.findByUserId(userId).orElse(null);
-    if (refreshToken == null) {
-      log.info("삭제할 RefreshToken 없음");
-      return;
-    }
-
-    refreshTokenRepository.deleteByToken(refreshToken);
+    refreshTokenRepository.deleteByUserId(userId);
 
     log.info("유저 {}의 RefreshToken 삭제 완료", userId);
   }

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/LogoutUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/LogoutUseCase.java
@@ -1,0 +1,5 @@
+package com.fisa.bank.user.application.usecase;
+
+public interface LogoutUseCase {
+  void execute();
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/RefreshTokenRepositoryImpl.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/persistence/repository/RefreshTokenRepositoryImpl.java
@@ -33,21 +33,13 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
   }
 
   @Override
-  public Optional<String> findByUserId(Long userId) {
-    return jpaRepository.findByUserId(userId).map(RefreshTokenEntity::getToken);
-  }
-
-  @Override
-  public Optional<Long> findUserIdByToken(String token) {
-    return jpaRepository
-        .findByToken(token)
-        .filter(entity -> !entity.isExpired())
-        .map(RefreshTokenEntity::getUserId);
-  }
-
-  @Override
   public void deleteByToken(String refreshToken) {
     jpaRepository.deleteByToken(refreshToken);
+  }
+
+  @Override
+  public void deleteByUserId(Long UserId) {
+    jpaRepository.deleteByUserId(UserId);
   }
 
   @Override

--- a/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
@@ -45,7 +45,12 @@ public class AuthController {
 
   @PostMapping("/logout")
   public ResponseEntity<Void> logout() {
-    logoutUseCase.execute();
-    return ResponseEntity.noContent().build();
+    try {
+      logoutUseCase.execute();
+      return ResponseEntity.noContent().build();
+    } catch (Exception e) {
+      log.error("로그아웃 처리 중 예외가 발생했습니다.", e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
@@ -8,28 +8,28 @@ import java.io.IOException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.fisa.bank.user.application.dto.RefreshTokenRequest;
 import com.fisa.bank.user.application.dto.RefreshTokenResponse;
+import com.fisa.bank.user.application.usecase.LogoutUseCase;
 import com.fisa.bank.user.application.usecase.UpdateTokenUseCase;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class AuthController {
 
   private final UpdateTokenUseCase updateTokenUseCase;
+  private final LogoutUseCase logoutUseCase;
 
-  @GetMapping("/api/login")
+  @GetMapping("/login")
   public void login(HttpServletResponse response) throws IOException {
     response.sendRedirect("/oauth2/authorization/loan-mate");
   }
 
-  @PostMapping("/api/auth/refresh")
+  @PostMapping("/auth/refresh")
   public ResponseEntity<RefreshTokenResponse> refresh(@RequestBody RefreshTokenRequest request) {
     try {
       RefreshTokenResponse response = updateTokenUseCase.execute(request.refreshToken());
@@ -41,5 +41,11 @@ public class AuthController {
       log.warn("토큰 갱신 중 예외 발생: {}", e.getMessage(), e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
+  }
+
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout() {
+    logoutUseCase.execute();
+    return ResponseEntity.noContent().build();
   }
 }


### PR DESCRIPTION
## 관련 이슈 
- #43 

## 기능 
- /api/logout 으로 요청 보내면 userId의 리프레시 토큰을 삭제 