### PR TITLE
[FEAT] 대출 목록, 상세 조회 시 AI 위험도, 코멘트 요청

### DIFF
--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/AiClient.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/AiClient.java
@@ -1,0 +1,5 @@
+package com.fisa.bank.common.application.service;
+
+public interface AiClient {
+  <T, B> T fetchOne(String endpoint, B body, Class<T> clazz);
+}

--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/AiClientImpl.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/AiClientImpl.java
@@ -1,0 +1,48 @@
+package com.fisa.bank.common.application.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fisa.bank.common.application.util.JsonNodeMapper;
+
+@Component
+@RequiredArgsConstructor
+public class AiClientImpl implements AiClient {
+  private final WebClient.Builder builder;
+
+  private final JsonNodeMapper jsonNodeMapper;
+
+  @Value("${ai-server.api-url}")
+  private String baseUrl;
+
+  @Override
+  public <T, B> T fetchOne(String endpoint, B body, Class<T> clazz) {
+    JsonNode root = executeRequest(endpoint, HttpMethod.GET, body, JsonNode.class);
+
+    if (root == null || root.isNull()) {
+      throw new IllegalStateException("응답이 null 입니다.");
+    }
+
+    return jsonNodeMapper.map(root.path("data"), clazz);
+  }
+
+  private WebClient client() {
+    return builder.build();
+  }
+
+  private <T, B> T executeRequest(
+      String endpoint, HttpMethod method, B body, Class<T> responseType) {
+    return client()
+        .method(method)
+        .uri(baseUrl + endpoint)
+        .bodyValue(body)
+        .retrieve()
+        .bodyToMono(responseType)
+        .block();
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/common/application/service/AiClientImpl.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/application/service/AiClientImpl.java
@@ -22,7 +22,7 @@ public class AiClientImpl implements AiClient {
 
   @Override
   public <T, B> T fetchOne(String endpoint, B body, Class<T> clazz) {
-    JsonNode root = executeRequest(endpoint, HttpMethod.GET, body, JsonNode.class);
+    JsonNode root = executeRequest(endpoint, HttpMethod.POST, body, JsonNode.class);
 
     if (root == null || root.isNull()) {
       throw new IllegalStateException("응답이 null 입니다.");

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoanDetailResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoanDetailResponse.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import java.math.BigDecimal;
 
 import com.fisa.bank.loan.application.model.LoanDetail;
-import com.fisa.bank.loan.persistence.enums.RiskLevel;
 import com.fisa.bank.persistence.loan.enums.LoanType;
 import com.fisa.bank.persistence.loan.enums.RepaymentType;
 
@@ -25,11 +24,7 @@ public class LoanDetailResponse {
   private final RepaymentType repaymentType;
   private final int progress;
 
-  // TODO: 나중에 위험도 계산 가능하면 final로 변경
-  private RiskLevel riskLevel;
-
   public static LoanDetailResponse from(Long loanId, LoanDetail loanDetail) {
-    // TODO: 위험도 세팅
     return LoanDetailResponse.builder()
         .loanId(loanId)
         .loanName(loanDetail.getName())

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoanListResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoanListResponse.java
@@ -2,6 +2,9 @@ package com.fisa.bank.loan.application.dto.response;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import javax.swing.*;
 
 import com.fisa.bank.loan.application.model.Loan;
 import com.fisa.bank.loan.persistence.enums.RiskLevel;
@@ -11,8 +14,8 @@ import com.fisa.bank.loan.persistence.enums.RiskLevel;
 public class LoanListResponse {
   private final Long loanId;
   private final String loanName;
-  // TODO: 나중에 위험도 계산 가능하면 final로 변경
-  private RiskLevel riskLevel;
+
+  @Setter private RiskLevel riskLevel;
 
   public static LoanListResponse from(Loan loan) {
     // TODO: 위험도 세팅

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoanListResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoanListResponse.java
@@ -2,9 +2,9 @@ package com.fisa.bank.loan.application.dto.response;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
-import javax.swing.*;
+import java.math.BigDecimal;
+import java.util.Map;
 
 import com.fisa.bank.loan.application.model.Loan;
 import com.fisa.bank.loan.persistence.enums.RiskLevel;
@@ -15,10 +15,11 @@ public class LoanListResponse {
   private final Long loanId;
   private final String loanName;
 
-  @Setter private RiskLevel riskLevel;
+  private final RiskLevel riskLevel;
 
-  public static LoanListResponse from(Loan loan) {
-    // TODO: 위험도 세팅
-    return new LoanListResponse(loan.getLoanId(), loan.getLoanName());
+  public static LoanListResponse from(Loan loan, Map<Long, BigDecimal> riskMap) {
+    BigDecimal risk = riskMap.get(loan.getLoanId());
+    RiskLevel level = RiskLevel.fromRiskScore(risk);
+    return new LoanListResponse(loan.getLoanId(), loan.getLoanName(), level);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanComment.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanComment.java
@@ -1,0 +1,11 @@
+package com.fisa.bank.loan.application.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Builder
+@AllArgsConstructor
+public class LoanComment {
+  private final Long loanLedgerId;
+  private final String comment;
+}

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanComment.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanComment.java
@@ -2,8 +2,10 @@ package com.fisa.bank.loan.application.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 @Builder
+@Getter
 @AllArgsConstructor
 public class LoanComment {
   private final Long loanLedgerId;

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanDetail.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanDetail.java
@@ -30,5 +30,6 @@ public class LoanDetail {
   private int term;
   private RepaymentStatus repaymentStatus;
 
+  @Setter private String comment;
   @Setter private Integer progress;
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanRiskDetail.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanRiskDetail.java
@@ -1,0 +1,12 @@
+package com.fisa.bank.loan.application.model;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+public class LoanRiskDetail {
+
+  private Long loanLedgerId;
+  private BigDecimal risk;
+}

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanRisks.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanRisks.java
@@ -1,0 +1,12 @@
+package com.fisa.bank.loan.application.model;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+public class LoanRisks {
+  private BigDecimal overallRisk;
+  private List<LoanRiskDetail> loans;
+}

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -36,7 +36,8 @@ public class LoanService implements ManageLoanUseCase {
   private final LoanReader loanReader;
   private final CoreBankingClient coreBankingClient;
   private final RequesterInfo requesterInfo;
-  private final String PREDICT_URL = "/api/ai/predict";
+  private final String PREDICT_URL = "/predict";
+  private final String LOAN_COMMENT = "/insight/loan";
   private final AiClient aiClient;
 
   @Override
@@ -71,6 +72,14 @@ public class LoanService implements ManageLoanUseCase {
     Integer progress = calculateProgressRate(loanDetail).intValueExact();
 
     loanDetail.setProgress(progress);
+    // 대출 LLM 코멘트
+    LoanComment loanComment = aiClient.fetchOne(LOAN_COMMENT, loanId, LoanComment.class);
+
+    if (!loanComment.getLoanLedgerId().equals(loanId)) {
+      throw new RuntimeException("요청한 loanId와 응답 loanLedgerId가 불일치합니다.");
+    }
+
+    loanDetail.setComment(loanComment.getComment());
     return LoanDetailResponse.from(loanId, loanDetail);
   }
 

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fisa.bank.common.application.service.CoreBankingClient;
+import com.fisa.bank.common.application.util.RequesterInfo;
 import com.fisa.bank.loan.application.dto.request.AutoDepositUpdateRequest;
 import com.fisa.bank.loan.application.dto.response.LoanAutoDepositResponse;
 import com.fisa.bank.loan.application.dto.response.LoanDetailResponse;
@@ -33,12 +34,14 @@ public class LoanService implements ManageLoanUseCase {
 
   private final LoanReader loanReader;
   private final CoreBankingClient coreBankingClient;
+  private final RequesterInfo requesterInfo;
 
   @Override
   @Transactional
-  public List<LoanListResponse> getLoans(Long userId) {
+  public List<LoanListResponse> getLoans() {
+    Long serviceUserId = requesterInfo.getCoreBankingUserId();
     List<LoanListResponse> loanLedgers =
-        loanReader.findLoans(userId).stream().map(LoanListResponse::from).toList();
+        loanReader.findLoans(serviceUserId).stream().map(LoanListResponse::from).toList();
     // TODO: 위험도 추가
     return loanLedgers;
   }
@@ -94,6 +97,7 @@ public class LoanService implements ManageLoanUseCase {
     coreBankingClient.fetchOneDelete(url);
   }
 
+  @Override
   public List<LoansWithPrepaymentBenefitResponse> getLoansWithPrepaymentBenefit() {
     List<LoansWithPrepaymentBenefitResponse> loansWithPrepaymentBenefitResponses =
         new ArrayList<>();

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/usecase/ManageLoanUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/usecase/ManageLoanUseCase.java
@@ -9,7 +9,7 @@ import com.fisa.bank.loan.application.dto.response.LoansWithPrepaymentBenefitRes
 
 public interface ManageLoanUseCase {
 
-  List<LoanListResponse> getLoans(Long userId);
+  List<LoanListResponse> getLoans();
 
   LoanDetailResponse getLoanDetail(Long loanId);
 

--- a/loan-mate/src/main/java/com/fisa/bank/loan/persistence/enums/RiskLevel.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/persistence/enums/RiskLevel.java
@@ -2,17 +2,34 @@ package com.fisa.bank.loan.persistence.enums;
 
 import lombok.Getter;
 
+import java.math.BigDecimal;
+
 @Getter
 public enum RiskLevel {
-  ONE(1),
-  TWO(2),
-  THREE(3),
-  FOUR(4),
-  FIVE(5);
+  ONE,
+  TWO,
+  THREE,
+  FOUR,
+  FIVE;
 
-  private final int num;
+  public static RiskLevel fromRiskScore(BigDecimal risk) {
+    if (risk == null) {
+      return null;
+    }
 
-  RiskLevel(int num) {
-    this.num = num;
+    // BigDecimal을 double로 변환 (0.0 ~ 1.0)
+    double r = risk.doubleValue();
+
+    if (r < 0.2) {
+      return ONE;
+    } else if (r < 0.4) {
+      return TWO;
+    } else if (r < 0.6) {
+      return THREE;
+    } else if (r < 0.8) {
+      return FOUR;
+    } else {
+      return FIVE;
+    }
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
@@ -28,8 +28,7 @@ public class LoanController {
 
   @GetMapping("/ledgers")
   public ApiResponse<SuccessBody<List<LoanListResponse>>> getLoans() {
-    // TODO: 로그인 완성되면 파라미터 제거
-    List<LoanListResponse> response = manageLoanUseCase.getLoans(Long.valueOf(1));
+    List<LoanListResponse> response = manageLoanUseCase.getLoans();
     return ApiResponseGenerator.success(ResponseCode.GET, response);
   }
 

--- a/loan-mate/src/main/resources/application.yml
+++ b/loan-mate/src/main/resources/application.yml
@@ -15,3 +15,6 @@ server:
     session:
       cookie:
         name: LOANMATESESSION
+
+ai-server:
+  api-uri: ${AI_SERVER_API_URL}

--- a/loan-mate/src/main/resources/application.yml
+++ b/loan-mate/src/main/resources/application.yml
@@ -17,4 +17,4 @@ server:
         name: LOANMATESESSION
 
 ai-server:
-  api-uri: ${AI_SERVER_API_URL}
+  api-url: ${AI_SERVER_API_URL}


### PR DESCRIPTION
## 관련 이슈
#45 

## 추가 사항
-  대출 목록 조회 시 해당 대출 위험도도 함께 조회되는 기능 추가했습니다.
- 위험도 (확률)
   - 0.0 ~ 0.2 미만 : ONE
   - 0.2 ~ 0.4 미만 : TWO
   - 0.4 ~ 0.6 미만 : THREE
   - 0.6 ~ 0.8 미만 : FOUR
   - 0.8 ~ 1.0 이하 : FIVE
 
- 대출 상세 조회 시 대출 LLM 코멘트 API 요청하는 코드 추가했습니다.
ex. "부채 관리가 안정적으로 이루어지고 있습니다.  지금처럼 꾸준히 유지해보세요."
