### PR TITLE
[FEAT] 로그인 쿠키 및 프론트엔드 리다이렉트 

### DIFF
--- a/loan-mate/src/main/java/com/fisa/bank/common/config/security/CustomOAuth2FailureHandler.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/config/security/CustomOAuth2FailureHandler.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
@@ -22,19 +23,20 @@ public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler 
   @Value("${app.front-fail-url}")
   private String frontFailUrl;
 
+  private final CookieUtil cookieUtil;
+
   @Override
   public void onAuthenticationFailure(
       HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
       throws IOException {
 
     log.error("OAuth2 로그인 실패: {}", exception.getMessage());
+    // 쿠키 삭제
+    ResponseCookie deleteAccess = cookieUtil.deleteCookie("accessToken");
+    ResponseCookie deleteRefresh = cookieUtil.deleteCookie("refreshToken");
 
-    // accessToken 삭제
-    response.addCookie(CookieUtil.deleteCookie("accessToken"));
-
-    // refreshToken 삭제
-    response.addCookie(CookieUtil.deleteCookie("refreshToken"));
-
+    response.addHeader("Set-Cookie", deleteAccess.toString());
+    response.addHeader("Set-Cookie", deleteRefresh.toString());
     // 실패 시 도메인으로 리다이렉트
     response.sendRedirect(frontFailUrl);
   }

--- a/loan-mate/src/main/java/com/fisa/bank/common/config/security/CustomOAuth2FailureHandler.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/config/security/CustomOAuth2FailureHandler.java
@@ -1,0 +1,41 @@
+package com.fisa.bank.common.config.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import com.fisa.bank.common.util.CookieUtil;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler {
+
+  @Value("${app.front-fail-url}")
+  private String frontFailUrl;
+
+  @Override
+  public void onAuthenticationFailure(
+      HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
+      throws IOException {
+
+    log.error("OAuth2 로그인 실패: {}", exception.getMessage());
+
+    // accessToken 삭제
+    response.addCookie(CookieUtil.deleteCookie("accessToken"));
+
+    // refreshToken 삭제
+    response.addCookie(CookieUtil.deleteCookie("refreshToken"));
+
+    // 실패 시 도메인으로 리다이렉트
+    response.sendRedirect(frontFailUrl);
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/common/config/security/CustomOAuth2SuccessHandler.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/config/security/CustomOAuth2SuccessHandler.java
@@ -48,8 +48,8 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
   @Value("${jwt.access-token-expiration}")
   private Long accessTokenExpiration;
 
-  @Value("${app.frontend-url}")
-  private String frontendUrl;
+  @Value("${app.front-success-url}")
+  private String frontSuccessUrl;
 
   @Override
   public void onAuthenticationSuccess(
@@ -107,7 +107,7 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
     response.addCookie(accessCookie);
     response.addCookie(refreshCookie);
 
-    String redirectUrl = frontendUrl + "/oauth/callback";
+    String redirectUrl = frontSuccessUrl;
     log.info("로그인 성공. 프론트엔드로 리다이렉트: {}", redirectUrl);
 
     response.setContentType(MediaType.TEXT_HTML_VALUE);

--- a/loan-mate/src/main/java/com/fisa/bank/common/util/CookieUtil.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/util/CookieUtil.java
@@ -1,23 +1,9 @@
 package com.fisa.bank.common.util;
 
-import jakarta.servlet.http.Cookie;
+import org.springframework.http.ResponseCookie;
 
-public class CookieUtil {
+public interface CookieUtil {
+  ResponseCookie createHttpOnlyCookie(String name, String value, int maxAgeSeconds);
 
-  public static Cookie createHttpOnlyCookie(
-      String name, String value, int maxAgeSeconds, boolean secure) {
-    Cookie cookie = new Cookie(name, value);
-    cookie.setHttpOnly(true);
-    cookie.setSecure(secure);
-    cookie.setPath("/");
-    cookie.setMaxAge(maxAgeSeconds);
-    return cookie;
-  }
-
-  public static Cookie deleteCookie(String name) {
-    Cookie cookie = new Cookie(name, null);
-    cookie.setPath("/");
-    cookie.setMaxAge(0);
-    return cookie;
-  }
+  ResponseCookie deleteCookie(String name);
 }

--- a/loan-mate/src/main/java/com/fisa/bank/common/util/CookieUtil.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/util/CookieUtil.java
@@ -1,0 +1,23 @@
+package com.fisa.bank.common.util;
+
+import jakarta.servlet.http.Cookie;
+
+public class CookieUtil {
+
+  public static Cookie createHttpOnlyCookie(
+      String name, String value, int maxAgeSeconds, boolean secure) {
+    Cookie cookie = new Cookie(name, value);
+    cookie.setHttpOnly(true);
+    cookie.setSecure(secure);
+    cookie.setPath("/");
+    cookie.setMaxAge(maxAgeSeconds);
+    return cookie;
+  }
+
+  public static Cookie deleteCookie(String name) {
+    Cookie cookie = new Cookie(name, null);
+    cookie.setPath("/");
+    cookie.setMaxAge(0);
+    return cookie;
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/common/util/CookieUtilDev.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/util/CookieUtilDev.java
@@ -1,0 +1,32 @@
+package com.fisa.bank.common.util;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile({"dev", "local"})
+public class CookieUtilDev implements CookieUtil {
+
+  @Override
+  public ResponseCookie createHttpOnlyCookie(String name, String value, int maxAgeSeconds) {
+    return ResponseCookie.from(name, value)
+        .httpOnly(true)
+        .secure(false) // dev는 secure=false
+        .sameSite("Lax")
+        .path("/")
+        .maxAge(maxAgeSeconds)
+        .build();
+  }
+
+  @Override
+  public ResponseCookie deleteCookie(String name) {
+    return ResponseCookie.from(name, "")
+        .httpOnly(true)
+        .secure(false)
+        .sameSite("Lax")
+        .path("/")
+        .maxAge(0)
+        .build();
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/common/util/CookieUtilProd.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/util/CookieUtilProd.java
@@ -1,0 +1,32 @@
+package com.fisa.bank.common.util;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("prod")
+public class CookieUtilProd implements CookieUtil {
+
+  @Override
+  public ResponseCookie createHttpOnlyCookie(String name, String value, int maxAgeSeconds) {
+    return ResponseCookie.from(name, value)
+        .httpOnly(true)
+        .secure(true) // prod는 https만 사용
+        .sameSite("None") // 크로스 도메인 필수
+        .path("/")
+        .maxAge(maxAgeSeconds)
+        .build();
+  }
+
+  @Override
+  public ResponseCookie deleteCookie(String name) {
+    return ResponseCookie.from(name, "")
+        .httpOnly(true)
+        .secure(true)
+        .sameSite("None")
+        .path("/")
+        .maxAge(0)
+        .build();
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/dto/LoginResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/dto/LoginResponse.java
@@ -1,3 +1,0 @@
-package com.fisa.bank.user.application.dto;
-
-public record LoginResponse(String accessToken, String refreshToken, Long userId) {}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/dto/RefreshTokenResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/dto/RefreshTokenResponse.java
@@ -1,3 +1,0 @@
-package com.fisa.bank.user.application.dto;
-
-public record RefreshTokenResponse(String accessToken, String refreshToken) {}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/dto/TokenPair.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/dto/TokenPair.java
@@ -1,0 +1,3 @@
+package com.fisa.bank.user.application.dto;
+
+public record TokenPair(String accessToken, String refreshToken) {}

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultUpdateTokenUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/DefaultUpdateTokenUseCase.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fisa.bank.common.application.service.JwtTokenGenerator;
 import com.fisa.bank.common.application.service.JwtTokenValidator;
-import com.fisa.bank.user.application.dto.RefreshTokenResponse;
+import com.fisa.bank.user.application.dto.TokenPair;
 import com.fisa.bank.user.application.repository.RefreshTokenRepository;
 
 @Slf4j
@@ -28,7 +28,7 @@ public class DefaultUpdateTokenUseCase implements UpdateTokenUseCase {
   private long refreshTokenExpiration;
 
   @Override
-  public RefreshTokenResponse execute(String refreshToken) {
+  public TokenPair execute(String refreshToken) {
     log.info("토큰 갱신 요청");
 
     Long userId = jwtTokenValidator.validateRefreshTokenAndGetUserId(refreshToken);
@@ -48,6 +48,6 @@ public class DefaultUpdateTokenUseCase implements UpdateTokenUseCase {
     refreshTokenRepository.save(userId, newRefreshToken, refreshTokenExpiry);
     log.info("새로운 Access/Refresh Token 발급 및 저장 완료. userId: {}", userId);
 
-    return new RefreshTokenResponse(newAccessToken, newRefreshToken);
+    return new TokenPair(newAccessToken, newRefreshToken);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/UpdateTokenUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/application/usecase/UpdateTokenUseCase.java
@@ -1,7 +1,7 @@
 package com.fisa.bank.user.application.usecase;
 
-import com.fisa.bank.user.application.dto.RefreshTokenResponse;
+import com.fisa.bank.user.application.dto.TokenPair;
 
 public interface UpdateTokenUseCase {
-  RefreshTokenResponse execute(String refreshToken);
+  TokenPair execute(String refreshToken);
 }

--- a/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
@@ -41,11 +41,6 @@ public class AuthController {
   @PostMapping("/auth/refresh")
   public ResponseEntity<Void> refresh(
       @CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
-
-    if (refreshToken == null) {
-      log.warn("Refresh Token 없음 (쿠키 없음)");
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-    }
     TokenPair newTokens;
     try {
       newTokens = updateTokenUseCase.execute(refreshToken);

--- a/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
@@ -13,7 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.fisa.bank.common.util.CookieUtil;
-import com.fisa.bank.user.application.dto.RefreshTokenResponse;
+import com.fisa.bank.user.application.dto.TokenPair;
 import com.fisa.bank.user.application.usecase.LogoutUseCase;
 import com.fisa.bank.user.application.usecase.UpdateTokenUseCase;
 
@@ -41,14 +41,14 @@ public class AuthController {
   }
 
   @PostMapping("/auth/refresh")
-  public ResponseEntity<RefreshTokenResponse> refresh(
+  public ResponseEntity<Void> refresh(
       @CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
 
     if (refreshToken == null) {
       log.warn("Refresh Token 없음 (쿠키 없음)");
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
-    RefreshTokenResponse newTokens;
+    TokenPair newTokens;
     try {
       newTokens = updateTokenUseCase.execute(refreshToken);
     } catch (IllegalArgumentException e) {

--- a/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
@@ -1,16 +1,18 @@
 package com.fisa.bank.user.presentation.controller;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import com.fisa.bank.user.application.dto.RefreshTokenRequest;
+import com.fisa.bank.common.util.CookieUtil;
 import com.fisa.bank.user.application.dto.RefreshTokenResponse;
 import com.fisa.bank.user.application.usecase.LogoutUseCase;
 import com.fisa.bank.user.application.usecase.UpdateTokenUseCase;
@@ -24,23 +26,60 @@ public class AuthController {
   private final UpdateTokenUseCase updateTokenUseCase;
   private final LogoutUseCase logoutUseCase;
 
+  @Value("${jwt.refresh-token-expiration}")
+  private Long refreshTokenExpiration;
+
+  @Value("${jwt.access-token-expiration}")
+  private Long accessTokenExpiration;
+
+  @Value("${app.cookie-secure:false}")
+  private boolean cookieSecure;
+
   @GetMapping("/login")
   public void login(HttpServletResponse response) throws IOException {
     response.sendRedirect("/oauth2/authorization/loan-mate");
   }
 
   @PostMapping("/auth/refresh")
-  public ResponseEntity<RefreshTokenResponse> refresh(@RequestBody RefreshTokenRequest request) {
+  public ResponseEntity<RefreshTokenResponse> refresh(
+      @CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
+
+    if (refreshToken == null) {
+      log.warn("Refresh Token 없음 (쿠키 없음)");
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    RefreshTokenResponse newTokens;
     try {
-      RefreshTokenResponse response = updateTokenUseCase.execute(request.refreshToken());
-      return ResponseEntity.ok(response);
+      newTokens = updateTokenUseCase.execute(refreshToken);
     } catch (IllegalArgumentException e) {
       log.warn("Refresh Token 검증 실패: {}", e.getMessage());
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     } catch (Exception e) {
-      log.warn("토큰 갱신 중 예외 발생: {}", e.getMessage(), e);
+      log.error("토큰 갱신 중 예외 발생", e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
+
+    // 쿠키 재발급
+    boolean secure = cookieSecure;
+
+    Cookie newAccessCookie =
+        CookieUtil.createHttpOnlyCookie(
+            "accessToken",
+            newTokens.accessToken(),
+            (int) (accessTokenExpiration / 1000L), // 30분
+            secure);
+
+    Cookie newRefreshCookie =
+        CookieUtil.createHttpOnlyCookie(
+            "refreshToken",
+            newTokens.refreshToken(),
+            (int) (refreshTokenExpiration / 1000L), // 7일
+            secure);
+
+    response.addCookie(newAccessCookie);
+    response.addCookie(newRefreshCookie);
+
+    return ResponseEntity.noContent().build();
   }
 
   @PostMapping("/logout")

--- a/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/user/presentation/controller/AuthController.java
@@ -83,9 +83,17 @@ public class AuthController {
   }
 
   @PostMapping("/logout")
-  public ResponseEntity<Void> logout() {
+  public ResponseEntity<Void> logout(HttpServletResponse response) {
     try {
+      // refreshToken 삭제
       logoutUseCase.execute();
+      // 쿠키 삭제
+      Cookie deleteAccessToken = CookieUtil.deleteCookie("accessToken");
+      Cookie deleteRefreshToken = CookieUtil.deleteCookie("refreshToken");
+
+      response.addCookie(deleteAccessToken);
+      response.addCookie(deleteRefreshToken);
+
       return ResponseEntity.noContent().build();
     } catch (Exception e) {
       log.error("로그아웃 처리 중 예외가 발생했습니다.", e);

--- a/loan-mate/src/main/resources/application.yml
+++ b/loan-mate/src/main/resources/application.yml
@@ -19,4 +19,3 @@ server:
 app:
   front-success-url: ${FRONT_URL}/login/success
   front-fail-url: ${FRONT_URL}/login/fail
-  cookie-secure: false

--- a/loan-mate/src/main/resources/application.yml
+++ b/loan-mate/src/main/resources/application.yml
@@ -15,3 +15,6 @@ server:
     session:
       cookie:
         name: LOANMATESESSION
+
+app:
+  front-end-url: ${}

--- a/loan-mate/src/main/resources/application.yml
+++ b/loan-mate/src/main/resources/application.yml
@@ -17,4 +17,5 @@ server:
         name: LOANMATESESSION
 
 app:
-  front-end-url: ${}
+  front-end-url: ${FRONT_URL}
+  cookie-secure: false

--- a/loan-mate/src/main/resources/application.yml
+++ b/loan-mate/src/main/resources/application.yml
@@ -17,5 +17,6 @@ server:
         name: LOANMATESESSION
 
 app:
-  front-end-url: ${FRONT_URL}
+  front-success-url: ${FRONT_URL}/login/success
+  front-fail-url: ${FRONT_URL}/login/fail
   cookie-secure: false


### PR DESCRIPTION
## 관련 이슈
- #48 

## 기능 
- 로그인 성공 시 토큰을 응답으로 주지 않고 쿠키로 저장
- 성공, 실패의 경우 handler를 통해서 프론트엔드로 리다이렉트 

## 공유사항
- 쿠키로 바꿔 로컬 스토리지보다 보안적인 측면에서 향상 및 로그아웃 시 쿠키 제거를 통해 액세스 토큰 제거 가능 