### PR TITLE
[HOTFIX] 쿠키 extract 로직 수정 

### DIFF
--- a/loan-mate/src/main/java/com/fisa/bank/common/config/security/JwtAuthenticationFilter.java
+++ b/loan-mate/src/main/java/com/fisa/bank/common/config/security/JwtAuthenticationFilter.java
@@ -62,6 +62,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
       return bearerToken.substring(BEARER_PREFIX.length());
     }
+
+    if (request.getCookies() != null) {
+      for (jakarta.servlet.http.Cookie cookie : request.getCookies()) {
+        if ("accessToken".equals(cookie.getName())) {
+          return cookie.getValue();
+        }
+      }
+    }
+
     return null;
   }
 }


### PR DESCRIPTION
- prod 에서 httpOnly를 true로 하면 프엔에서 쿠키를 읽어 액세스 토큰을 헤더로 나을 수 없음
- 쿠키로 판별하는 로직 추가 