### PR TITLE
[FEAT] 모든 대출 상세 정보 조회 api 추가

### DIFF
--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoanDetailResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoanDetailResponse.java
@@ -19,6 +19,7 @@ public class LoanDetailResponse {
   private final BigDecimal remainPrincipal;
   private final BigDecimal principal;
   private final BigDecimal monthlyRepayment;
+  private final BigDecimal interestPayment;
   private final String accountNumber;
   private final LoanType loanType;
   private final RepaymentType repaymentType;
@@ -30,6 +31,7 @@ public class LoanDetailResponse {
         .loanName(loanDetail.getName())
         .loanType(loanDetail.getLoanType())
         .monthlyRepayment(loanDetail.getMonthlyRepayment())
+        .interestPayment(loanDetail.getInterestPayment())
         .repaymentType(loanDetail.getRepaymentType())
         .accountNumber(loanDetail.getAccountNumber())
         .remainPrincipal(loanDetail.getRemainPrincipal())

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoanDetailResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/LoanDetailResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 import com.fisa.bank.loan.application.model.LoanDetail;
 import com.fisa.bank.persistence.loan.enums.LoanType;
@@ -24,6 +25,7 @@ public class LoanDetailResponse {
   private final LoanType loanType;
   private final RepaymentType repaymentType;
   private final int progress;
+  private final LocalDateTime nextRepaymentDate;
 
   public static LoanDetailResponse from(Long loanId, LoanDetail loanDetail) {
     return LoanDetailResponse.builder()
@@ -37,6 +39,7 @@ public class LoanDetailResponse {
         .remainPrincipal(loanDetail.getRemainPrincipal())
         .principal(loanDetail.getPrincipal())
         .progress(loanDetail.getProgress())
+        .nextRepaymentDate(loanDetail.getNextRepaymentDate())
         .build();
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanDetail.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanDetail.java
@@ -18,10 +18,12 @@ import com.fisa.bank.persistence.loan.enums.RepaymentType;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LoanDetail {
+  private Long loanLedgerId;
   private String name;
   private BigDecimal remainPrincipal;
   private BigDecimal principal;
   private BigDecimal monthlyRepayment;
+  private BigDecimal interestPayment;
   private String accountNumber;
   private LoanType loanType;
   private RepaymentType repaymentType;

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanDetail.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/model/LoanDetail.java
@@ -28,6 +28,7 @@ public class LoanDetail {
   private LoanType loanType;
   private RepaymentType repaymentType;
   private LocalDateTime lastRepaymentDate;
+  private LocalDateTime nextRepaymentDate;
   private LocalDateTime createdAt;
   private int term;
   private RepaymentStatus repaymentStatus;

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -184,9 +184,7 @@ public class LoanService implements ManageLoanUseCase {
             .map(
                 loanDetail -> {
                   // progress 계산
-                  Integer progress = calculateProgressRate(loanDetail).intValueExact();
-                  loanDetail.setProgress(progress);
-
+                  loanDetail.setProgress(calculateProgressRate(loanDetail).intValueExact());
                   // DTO 변환
                   return LoanDetailResponse.from(loanDetail.getLoanLedgerId(), loanDetail);
                 })

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -174,4 +174,23 @@ public class LoanService implements ManageLoanUseCase {
                     .build())
         .toList();
   }
+
+  @Override
+  public List<LoanDetailResponse> getLoanDetails() {
+    List<LoanDetail> loanDetails = loanReader.findLoanDetails();
+
+    List<LoanDetailResponse> responseList =
+        loanDetails.stream()
+            .map(
+                loanDetail -> {
+                  // progress 계산
+                  Integer progress = calculateProgressRate(loanDetail).intValueExact();
+                  loanDetail.setProgress(progress);
+
+                  // DTO 변환
+                  return LoanDetailResponse.from(loanDetail.getLoanLedgerId(), loanDetail);
+                })
+            .toList();
+    return responseList;
+  }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
@@ -33,6 +33,12 @@ public class LoanReader {
     return coreBankingClient.fetchOne(url, LoanDetail.class);
   }
 
+  public List<LoanDetail> findLoanDetails() {
+    String url = "/loans/ledgers/details";
+
+    return coreBankingClient.fetchList(url, LoanDetail.class);
+  }
+
   public List<Loan> findLoans(Long userId) {
     return loanRepository.getLoans(UserId.of(userId));
   }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
@@ -26,6 +26,7 @@ public class LoanReader {
   private final CoreBankingClient coreBankingClient;
 
   private static final String PREPAYMENT_INFOS_URL = "/loans/prepayment-infos";
+  private static final String LOAN_DETAILS_URL = "/loans/ledgers/details";
 
   public LoanDetail findLoanDetail(Long loanId) {
     String url = "/loans/ledger/" + loanId;
@@ -34,9 +35,7 @@ public class LoanReader {
   }
 
   public List<LoanDetail> findLoanDetails() {
-    String url = "/loans/ledgers/details";
-
-    return coreBankingClient.fetchList(url, LoanDetail.class);
+    return coreBankingClient.fetchList(LOAN_DETAILS_URL, LoanDetail.class);
   }
 
   public List<Loan> findLoans(Long userId) {

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/usecase/ManageLoanUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/usecase/ManageLoanUseCase.java
@@ -19,4 +19,6 @@ public interface ManageLoanUseCase {
   List<LoansWithPrepaymentBenefitResponse> getLoansWithPrepaymentBenefit();
 
   List<AutoDepositResponse> getAutoDepositSummary();
+
+  List<LoanDetailResponse> getLoanDetails();
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
@@ -78,4 +78,11 @@ public class LoanController {
 
     return ApiResponseGenerator.success(ResponseCode.GET, summary);
   }
+
+  @GetMapping("/ledgers/details")
+  public ApiResponse<SuccessBody<List<LoanDetailResponse>>> getLoanDetails() {
+    log.info("모든 대출 세부 정보 조회");
+    List<LoanDetailResponse> loanDetails = manageLoanUseCase.getLoanDetails();
+    return ApiResponseGenerator.success(ResponseCode.GET, loanDetails);
+  }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #60

## 추가 사항
내가 가입한 대출 상세 정보를 모두 조회하는 api입니다.
코어 뱅킹의 같은 api를 호출해서 응답을 받아옵니다.