### PR TITLE
[FEAT] ai simulation api 구현

### DIFF
--- a/loan-mate/src/main/java/com/fisa/bank/account/application/dto/request/TransferRequest.java
+++ b/loan-mate/src/main/java/com/fisa/bank/account/application/dto/request/TransferRequest.java
@@ -5,21 +5,10 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 
 public record TransferRequest(
-
-        @NotBlank(message = "보내는 계좌번호는 필수입니다.")
-        String fromAccountNumber,
-
-        @NotBlank(message = "받는 계좌번호는 필수입니다.")
-        String toAccountNumber,
-
-        @NotBlank(message = "받는 은행 코드는 필수입니다.")
-        String toBankCode,
-
-        @NotNull(message = "송금 금액은 null일 수 없습니다.")
-        @Positive(message = "송금 금액은 0보다 커야 합니다.")
-        BigDecimal amount
-
-) {}
+    @NotBlank(message = "보내는 계좌번호는 필수입니다.") String fromAccountNumber,
+    @NotBlank(message = "받는 계좌번호는 필수입니다.") String toAccountNumber,
+    @NotBlank(message = "받는 은행 코드는 필수입니다.") String toBankCode,
+    @NotNull(message = "송금 금액은 null일 수 없습니다.") @Positive(message = "송금 금액은 0보다 커야 합니다.")
+        BigDecimal amount) {}

--- a/loan-mate/src/main/java/com/fisa/bank/account/application/dto/response/ApiResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/account/application/dto/response/ApiResponse.java
@@ -1,7 +1,3 @@
 package com.fisa.bank.account.application.dto.response;
 
-public record ApiResponse<T>(
-        String code,
-        String message,
-        T data
-) {}
+public record ApiResponse<T>(String code, String message, T data) {}

--- a/loan-mate/src/main/java/com/fisa/bank/account/application/dto/response/SuccessBody.java
+++ b/loan-mate/src/main/java/com/fisa/bank/account/application/dto/response/SuccessBody.java
@@ -1,5 +1,3 @@
 package com.fisa.bank.account.application.dto.response;
 
-public record SuccessBody<T>(
-        T data
-) {}
+public record SuccessBody<T>(T data) {}

--- a/loan-mate/src/main/java/com/fisa/bank/account/application/dto/response/TransferResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/account/application/dto/response/TransferResponse.java
@@ -1,15 +1,13 @@
 package com.fisa.bank.account.application.dto.response;
 
-
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 public record TransferResponse(
-        String fromAccountNumber,
-        String toAccountNumber,
-        BigDecimal amount,
-        BigDecimal fromBalanceAfter,
-        BigDecimal toBalanceAfter,
-        LocalDateTime transactionAt,
-        String message
-) {}
+    String fromAccountNumber,
+    String toAccountNumber,
+    BigDecimal amount,
+    BigDecimal fromBalanceAfter,
+    BigDecimal toBalanceAfter,
+    LocalDateTime transactionAt,
+    String message) {}

--- a/loan-mate/src/main/java/com/fisa/bank/account/application/service/AccountService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/account/application/service/AccountService.java
@@ -1,25 +1,18 @@
 package com.fisa.bank.account.application.service;
 
-import com.fisa.bank.account.application.dto.request.TransferRequest;
-import com.fisa.bank.account.application.dto.response.ApiResponse;
-import com.fisa.bank.account.application.dto.response.SuccessBody;
-import com.fisa.bank.account.application.dto.response.TransferResponse;
-import com.fisa.bank.common.application.util.core_bank.CoreBankingClient;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import com.fisa.bank.account.application.dto.request.TransferRequest;
+import com.fisa.bank.account.application.dto.response.TransferResponse;
 import com.fisa.bank.account.application.model.AccountDetail;
 import com.fisa.bank.account.application.repository.AccountDetailRepository;
 import com.fisa.bank.common.application.util.RequesterInfo;
+import com.fisa.bank.common.application.util.core_bank.CoreBankingClient;
 import com.fisa.bank.persistence.user.entity.id.UserId;
-import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -34,10 +27,6 @@ public class AccountService {
   }
 
   public TransferResponse transfer(TransferRequest request) {
-    return coreBankingClient.post(
-            "/api/accounts/transfer",
-            request,
-            TransferResponse.class
-    );
+    return coreBankingClient.post("/api/accounts/transfer", request, TransferResponse.class);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/account/persistence/repository/JpaAccountRepository.java
+++ b/loan-mate/src/main/java/com/fisa/bank/account/persistence/repository/JpaAccountRepository.java
@@ -3,15 +3,14 @@ package com.fisa.bank.account.persistence.repository;
 import java.util.List;
 import java.util.Optional;
 
-import com.fisa.bank.persistence.account.entity.id.AccountId;
-import com.fisa.bank.persistence.user.entity.id.UserId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.fisa.bank.persistence.account.entity.Account;
-import com.fisa.bank.persistence.account.repository.AccountRepository;
+import com.fisa.bank.persistence.account.entity.id.AccountId;
 import com.fisa.bank.persistence.user.entity.User;
+import com.fisa.bank.persistence.user.entity.id.UserId;
 
 public interface JpaAccountRepository extends JpaRepository<Account, AccountId> {
   @Query("""

--- a/loan-mate/src/main/java/com/fisa/bank/account/presentation/controller/AccountController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/account/presentation/controller/AccountController.java
@@ -1,7 +1,5 @@
 package com.fisa.bank.account.presentation.controller;
 
-import com.fisa.bank.account.application.dto.request.TransferRequest;
-import com.fisa.bank.account.application.dto.response.TransferResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -9,6 +7,8 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.*;
 
+import com.fisa.bank.account.application.dto.request.TransferRequest;
+import com.fisa.bank.account.application.dto.response.TransferResponse;
 import com.fisa.bank.account.application.model.AccountDetail;
 import com.fisa.bank.account.application.service.AccountService;
 

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/client/LoanAiClient.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/client/LoanAiClient.java
@@ -8,6 +8,8 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 import com.fisa.bank.common.application.util.ai.AiClient;
+import com.fisa.bank.loan.application.dto.request.AiSimulationRequest;
+import com.fisa.bank.loan.application.dto.response.AiSimulationResponse;
 import com.fisa.bank.loan.application.model.LoanComment;
 import com.fisa.bank.loan.application.model.LoanRisks;
 
@@ -16,6 +18,7 @@ import com.fisa.bank.loan.application.model.LoanRisks;
 public class LoanAiClient {
   private static final String PREDICT_URL = "/predict";
   private static final String LOAN_COMMENT_URL = "/insight/loan";
+  private static final String AI_SIMULATION_URL = "/simulation";
 
   private static final String AI_REQUEST_KEY_USER_ID = "user_id";
   private static final String AI_REQUEST_KEY_LOAN_LEDGER_ID = "loan_ledger_id";
@@ -35,5 +38,9 @@ public class LoanAiClient {
   public LoanComment fetchLoanComment(Long loanLedgerId) {
     return aiClient.fetchOne(
         LOAN_COMMENT_URL, Map.of(AI_REQUEST_KEY_LOAN_LEDGER_ID, loanLedgerId), LoanComment.class);
+  }
+
+  public AiSimulationResponse processAiSimulation(AiSimulationRequest body) {
+    return aiClient.fetchOne(AI_SIMULATION_URL, body, AiSimulationResponse.class);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/request/AiSimulationRequest.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/request/AiSimulationRequest.java
@@ -1,0 +1,18 @@
+package com.fisa.bank.loan.application.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+public class AiSimulationRequest {
+  @Setter private Long userId;
+
+  private final List<ChangeItem> changes;
+
+  public AiSimulationRequest() {
+    // changes가 null로 들어오면 NPE 방지
+    this.changes = List.of();
+  }
+}

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/request/AiSimulationRequest.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/request/AiSimulationRequest.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Getter
 public class AiSimulationRequest {
-  @Setter private Long userId;
+  @Setter private Long user_id;
 
   private final List<ChangeItem> changes;
 

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/request/AiSimulationRequest.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/request/AiSimulationRequest.java
@@ -5,14 +5,15 @@ import lombok.Setter;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 @Getter
 public class AiSimulationRequest {
   @Setter private Long userId;
 
   private final List<ChangeItem> changes;
 
-  public AiSimulationRequest() {
-    // changes가 null로 들어오면 NPE 방지
-    this.changes = List.of();
+  public AiSimulationRequest(@JsonProperty("changes") List<ChangeItem> changes) {
+    this.changes = changes == null ? List.of() : changes;
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/request/ChangeItem.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/request/ChangeItem.java
@@ -1,0 +1,16 @@
+package com.fisa.bank.loan.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChangeItem {
+  private String type; // "income" or "expense"
+  private String name;
+  private BigDecimal amount;
+}

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/request/ChangeItem.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/request/ChangeItem.java
@@ -6,11 +6,13 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 
+import com.fisa.bank.loan.persistence.enums.ChangeItemType;
+
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class ChangeItem {
-  private String type; // "income" or "expense"
+  private ChangeItemType type; // "income" or "expense"
   private String name;
   private BigDecimal amount;
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/AiSimulationResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/AiSimulationResponse.java
@@ -1,19 +1,21 @@
 package com.fisa.bank.loan.application.dto.response;
 
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@RequiredArgsConstructor
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
 public class AiSimulationResponse {
   @JsonProperty("base_risk_score")
-  private final BigDecimal baseRiskScore;
+  private BigDecimal baseRiskScore;
 
   @JsonProperty("simulated_risk_score")
-  private final BigDecimal simulatedRiskScore;
+  private BigDecimal simulatedRiskScore;
 
-  private final BigDecimal delta;
-  private final String explanation;
+  private BigDecimal delta;
+  private String explanation;
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/AiSimulationResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/AiSimulationResponse.java
@@ -1,0 +1,19 @@
+package com.fisa.bank.loan.application.dto.response;
+
+import lombok.RequiredArgsConstructor;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@RequiredArgsConstructor
+public class AiSimulationResponse {
+  @JsonProperty("base_risk_score")
+  private final BigDecimal baseRiskScore;
+
+  @JsonProperty("simulated_risk_score")
+  private final BigDecimal simulatedRiskScore;
+
+  private final BigDecimal delta;
+  private final String explanation;
+}

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/AutoDepositResponse.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/dto/response/AutoDepositResponse.java
@@ -1,10 +1,11 @@
 package com.fisa.bank.loan.application.dto.response;
 
-import com.fisa.bank.persistence.loan.entity.id.LoanLedgerId;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
+
+import com.fisa.bank.persistence.loan.entity.id.LoanLedgerId;
 
 @Getter
 @Builder

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -19,12 +19,15 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fisa.bank.common.application.util.RequesterInfo;
 import com.fisa.bank.loan.application.client.LoanAiClient;
 import com.fisa.bank.loan.application.client.LoanCoreBankingClient;
+import com.fisa.bank.loan.application.dto.request.AiSimulationRequest;
+import com.fisa.bank.loan.application.dto.response.*;
 import com.fisa.bank.loan.application.dto.response.AutoDepositResponse;
 import com.fisa.bank.loan.application.dto.response.LoanAiCommentResponse;
 import com.fisa.bank.loan.application.dto.response.LoanAutoDepositResponse;
 import com.fisa.bank.loan.application.dto.response.LoanDetailResponse;
 import com.fisa.bank.loan.application.dto.response.LoanListResponse;
 import com.fisa.bank.loan.application.dto.response.LoansWithPrepaymentBenefitResponse;
+import com.fisa.bank.loan.application.model.*;
 import com.fisa.bank.loan.application.model.InterestDetail;
 import com.fisa.bank.loan.application.model.Loan;
 import com.fisa.bank.loan.application.model.LoanComment;
@@ -191,5 +194,11 @@ public class LoanService implements ManageLoanUseCase {
                 })
             .toList();
     return responseList;
+  }
+
+  @Override
+  public AiSimulationResponse processAiSimulation(AiSimulationRequest request) {
+    request.setUserId(requesterInfo.getCoreBankingUserId());
+    return loanAiClient.processAiSimulation(request);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -198,7 +198,7 @@ public class LoanService implements ManageLoanUseCase {
 
   @Override
   public AiSimulationResponse processAiSimulation(AiSimulationRequest request) {
-    request.setUserId(requesterInfo.getCoreBankingUserId());
+    request.setUser_id(requesterInfo.getCoreBankingUserId());
     return loanAiClient.processAiSimulation(request);
   }
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -169,7 +169,7 @@ public class LoanService implements ManageLoanUseCase {
         .map(
             ledger ->
                 AutoDepositResponse.builder()
-                        .loanLedgerId(ledger.getLoanLedgerId())
+                    .loanLedgerId(ledger.getLoanLedgerId())
                     .loanName(
                         ledger.getLoanProduct() != null ? ledger.getLoanProduct().getName() : null)
                     .accountBalance(

--- a/loan-mate/src/main/java/com/fisa/bank/loan/application/usecase/ManageLoanUseCase.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/application/usecase/ManageLoanUseCase.java
@@ -2,6 +2,7 @@ package com.fisa.bank.loan.application.usecase;
 
 import java.util.List;
 
+import com.fisa.bank.loan.application.dto.request.AiSimulationRequest;
 import com.fisa.bank.loan.application.dto.response.*;
 
 public interface ManageLoanUseCase {
@@ -23,4 +24,6 @@ public interface ManageLoanUseCase {
   List<LoanDetailResponse> getLoanDetails();
 
   LoanAiCommentResponse getAiComment(Long loanLedgerId);
+
+  AiSimulationResponse processAiSimulation(AiSimulationRequest request);
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/persistence/enums/ChangeItemType.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/persistence/enums/ChangeItemType.java
@@ -1,0 +1,6 @@
+package com.fisa.bank.loan.persistence.enums;
+
+public enum ChangeItemType {
+  INCOME,
+  EXPENSE
+}

--- a/loan-mate/src/main/java/com/fisa/bank/loan/persistence/enums/ChangeItemType.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/persistence/enums/ChangeItemType.java
@@ -1,6 +1,6 @@
 package com.fisa.bank.loan.persistence.enums;
 
 public enum ChangeItemType {
-  INCOME,
-  EXPENSE
+  income,
+  expense
 }

--- a/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
@@ -77,6 +77,22 @@ public class LoanController {
     return ApiResponseGenerator.success(ResponseCode.UPDATE);
   }
 
+  @GetMapping("/auto-deposit-summary")
+  public ApiResponse<SuccessBody<List<AutoDepositResponse>>> getUserLoanSimpleSummary() {
+    log.info("자동 예치 정보 조회");
+
+    List<AutoDepositResponse> summary = manageLoanUseCase.getAutoDepositSummary();
+
+    return ApiResponseGenerator.success(ResponseCode.GET, summary);
+  }
+
+  @GetMapping("/ledgers/details")
+  public ApiResponse<SuccessBody<List<LoanDetailResponse>>> getLoanDetails() {
+    log.info("모든 대출 세부 정보 조회");
+    List<LoanDetailResponse> loanDetails = manageLoanUseCase.getLoanDetails();
+    return ApiResponseGenerator.success(ResponseCode.GET, loanDetails);
+  }
+
   @PostMapping("/ai-simulation")
   public ApiResponse<SuccessBody<AiSimulationResponse>> processAiSimulation(
       @RequestBody AiSimulationRequest request) {

--- a/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
+++ b/loan-mate/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
@@ -12,6 +12,7 @@ import com.fisa.bank.common.presentation.response.ApiResponse;
 import com.fisa.bank.common.presentation.response.ApiResponseGenerator;
 import com.fisa.bank.common.presentation.response.body.SuccessBody;
 import com.fisa.bank.common.presentation.response.code.ResponseCode;
+import com.fisa.bank.loan.application.dto.request.AiSimulationRequest;
 import com.fisa.bank.loan.application.dto.request.AutoDepositUpdateRequest;
 import com.fisa.bank.loan.application.dto.response.*;
 import com.fisa.bank.loan.application.usecase.ManageLoanUseCase;
@@ -76,19 +77,11 @@ public class LoanController {
     return ApiResponseGenerator.success(ResponseCode.UPDATE);
   }
 
-  @GetMapping("/auto-deposit-summary")
-  public ApiResponse<SuccessBody<List<AutoDepositResponse>>> getUserLoanSimpleSummary() {
-    log.info("자동 예치 정보 조회");
-
-    List<AutoDepositResponse> summary = manageLoanUseCase.getAutoDepositSummary();
-
-    return ApiResponseGenerator.success(ResponseCode.GET, summary);
-  }
-
-  @GetMapping("/ledgers/details")
-  public ApiResponse<SuccessBody<List<LoanDetailResponse>>> getLoanDetails() {
-    log.info("모든 대출 세부 정보 조회");
-    List<LoanDetailResponse> loanDetails = manageLoanUseCase.getLoanDetails();
-    return ApiResponseGenerator.success(ResponseCode.GET, loanDetails);
+  @PostMapping("/ai-simulation")
+  public ApiResponse<SuccessBody<AiSimulationResponse>> processAiSimulation(
+      @RequestBody AiSimulationRequest request) {
+    log.info("AI Simulation 실행");
+    AiSimulationResponse aiSimulationResponse = manageLoanUseCase.processAiSimulation(request);
+    return ApiResponseGenerator.success(ResponseCode.GET, aiSimulationResponse);
   }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #67 

## 추가한 기능
- AI Simulation api를 구현했습니다.
- 추가된 고정 지출/수입을 바디로 전송합니다.
- 기존 위험도, ai 측정 위험도, 두 위험도의 차이(delta), 코멘트를 반환합니다.