### PR TITLE
[FIX] 프론트엔드와 연동하는 과정에서 필요한 부분 추가

### DIFF
--- a/loan-mate/src/main/java/com/fisa/bank/account/application/model/spending/RecommendedSpending.java
+++ b/loan-mate/src/main/java/com/fisa/bank/account/application/model/spending/RecommendedSpending.java
@@ -7,4 +7,6 @@ import com.fisa.bank.persistence.account.enums.ConsumptionCategory;
 
 public record RecommendedSpending(
     BigDecimal variableSpendingBudget,
-    Map<ConsumptionCategory, BigDecimal> categoryRecommendation) {}
+    Map<ConsumptionCategory, BigDecimal> categoryRecommendation,
+    boolean isCustomized,
+    Map<ConsumptionCategory, BigDecimal> aiOriginalValues) {}

--- a/loan-mate/src/main/java/com/fisa/bank/account/application/service/ai/AiExpenditureService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/account/application/service/ai/AiExpenditureService.java
@@ -126,7 +126,7 @@ public class AiExpenditureService {
 
   private BigDecimal roundValue(BigDecimal value) {
     if (value == null) {
-      return ZERO.setScale(1);
+      return ZERO.setScale(1, RoundingMode.HALF_UP);
     }
     return value.setScale(1, RoundingMode.HALF_UP);
   }

--- a/loan-mate/src/main/java/com/fisa/bank/account/application/service/ai/AiExpenditureService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/account/application/service/ai/AiExpenditureService.java
@@ -117,10 +117,7 @@ public class AiExpenditureService {
     }
 
     for (ConsumptionCategory category : ConsumptionCategory.values()) {
-      BigDecimal value = ratios.get(category);
-      if (value == null) {
-        value = ZERO;
-      }
+      BigDecimal value = ratios.getOrDefault(category, ZERO);
       rounded.put(category, value.setScale(1, RoundingMode.HALF_UP));
     }
 

--- a/loan-mate/src/main/java/com/fisa/bank/account/application/service/ai/AiExpenditureService.java
+++ b/loan-mate/src/main/java/com/fisa/bank/account/application/service/ai/AiExpenditureService.java
@@ -112,15 +112,10 @@ public class AiExpenditureService {
   private Map<ConsumptionCategory, BigDecimal> roundRatios(
       Map<ConsumptionCategory, BigDecimal> ratios) {
     Map<ConsumptionCategory, BigDecimal> rounded = new EnumMap<>(ConsumptionCategory.class);
-    if (ratios == null) {
-      return rounded;
-    }
-
     for (ConsumptionCategory category : ConsumptionCategory.values()) {
-      BigDecimal value = ratios.getOrDefault(category, ZERO);
+      BigDecimal value = (ratios != null) ? ratios.getOrDefault(category, ZERO) : ZERO;
       rounded.put(category, value.setScale(1, RoundingMode.HALF_UP));
     }
-
     return rounded;
   }
 


### PR DESCRIPTION
- 연령대별 바른 소비 비율을 디폴트로 넣어주기 
- ai에게 요청 보낼 때 소수점 한 자리까지 반올림해서 요청 